### PR TITLE
Add optional ticket link to worktree creation

### DIFF
--- a/Sources/DraftFrameKit/Agent.swift
+++ b/Sources/DraftFrameKit/Agent.swift
@@ -105,9 +105,15 @@ enum AgentKind: String, CaseIterable {
   }
 
   /// Full command line that launches this agent with the given model
-  /// (empty = the CLI's own default).
-  func launchCommand(binPath: String, modelId: String) -> String {
-    modelId.isEmpty ? binPath : "\(binPath) --model \(modelId)"
+  /// (empty = the CLI's own default) and, optionally, an initial prompt the
+  /// agent starts working on immediately. Both CLIs take the prompt as a
+  /// positional argument.
+  func launchCommand(binPath: String, modelId: String, initialPrompt: String? = nil) -> String {
+    var cmd = modelId.isEmpty ? binPath : "\(binPath) --model \(modelId)"
+    if let prompt = initialPrompt, !prompt.isEmpty {
+      cmd += " \(shellSingleQuote(prompt))"
+    }
+    return cmd
   }
 }
 

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -755,33 +755,19 @@ final class DFSidebar: NSView {
     guard sender.tag >= 0, sender.tag < projects.count else { return }
     let project = projects[sender.tag]
 
-    let alert = NSAlert()
-    alert.messageText = "New Worktree"
-    alert.informativeText = "Enter a name for the new worktree branch in \(project.name):"
-    alert.addButton(withTitle: "Create")
-    alert.addButton(withTitle: "Cancel")
-
-    let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-    input.placeholderString = "feature-name"
-    alert.accessoryView = input
-
     guard let win = window else { return }
-    alert.beginSheetModal(for: win) { response in
-      guard response == .alertFirstButtonReturn else { return }
-      let name = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !name.isEmpty else { return }
-
-      do {
-        let path = try WorktreeManager.shared.createWorktree(
-          repoRoot: project.path, name: name)
-        SessionManager.shared.createSession(name: name, worktreePath: path)
-        self.refreshWorktrees()
-      } catch {
-        let errAlert = NSAlert()
-        errAlert.messageText = "Worktree Error"
-        errAlert.informativeText = error.localizedDescription
-        errAlert.runModal()
-      }
+    NewWorktreeDialog.present(
+      on: win, title: "New Worktree",
+      message: "Enter a name for the new worktree branch in \(project.name):"
+    ) { result in
+      guard
+        let path = NewWorktreeDialog.createWorktreeReportingErrors(
+          repoRoot: project.path, name: result.name)
+      else { return }
+      SessionManager.shared.createSession(
+        name: result.name, worktreePath: path,
+        initialPrompt: result.ticket.map(TicketLink.kickoffPrompt))
+      self.refreshWorktrees()
     }
   }
 
@@ -795,33 +781,19 @@ final class DFSidebar: NSView {
     let sourceName =
       source.branch.isEmpty ? (source.path as NSString).lastPathComponent : source.branch
 
-    let alert = NSAlert()
-    alert.messageText = "New Worktree from \(sourceName)"
-    alert.informativeText = "Enter a name for the new worktree branch based on \(sourceName):"
-    alert.addButton(withTitle: "Create")
-    alert.addButton(withTitle: "Cancel")
-
-    let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-    input.placeholderString = "feature-name"
-    alert.accessoryView = input
-
     guard let win = window else { return }
-    alert.beginSheetModal(for: win) { response in
-      guard response == .alertFirstButtonReturn else { return }
-      let name = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !name.isEmpty else { return }
-
-      do {
-        let path = try WorktreeManager.shared.createWorktree(
-          repoRoot: req.repoRoot, name: name, baseBranch: base)
-        SessionManager.shared.createSession(name: name, worktreePath: path)
-        self.refreshWorktrees()
-      } catch {
-        let errAlert = NSAlert()
-        errAlert.messageText = "Worktree Error"
-        errAlert.informativeText = error.localizedDescription
-        errAlert.runModal()
-      }
+    NewWorktreeDialog.present(
+      on: win, title: "New Worktree from \(sourceName)",
+      message: "Enter a name for the new worktree branch based on \(sourceName):"
+    ) { result in
+      guard
+        let path = NewWorktreeDialog.createWorktreeReportingErrors(
+          repoRoot: req.repoRoot, name: result.name, baseBranch: base)
+      else { return }
+      SessionManager.shared.createSession(
+        name: result.name, worktreePath: path,
+        initialPrompt: result.ticket.map(TicketLink.kickoffPrompt))
+      self.refreshWorktrees()
     }
   }
 

--- a/Sources/DraftFrameKit/DFTerminalPane.swift
+++ b/Sources/DraftFrameKit/DFTerminalPane.swift
@@ -199,8 +199,11 @@ final class DFTerminalPane: NSView {
     createNewSession()
   }
 
-  func createNewSession(name: String? = nil, worktreePath: String? = nil) {
-    SessionManager.shared.createSession(name: name, worktreePath: worktreePath)
+  func createNewSession(
+    name: String? = nil, worktreePath: String? = nil, initialPrompt: String? = nil
+  ) {
+    SessionManager.shared.createSession(
+      name: name, worktreePath: worktreePath, initialPrompt: initialPrompt)
   }
 
   /// Ensure there's at least one session on first display.

--- a/Sources/DraftFrameKit/DFWindowController.swift
+++ b/Sources/DraftFrameKit/DFWindowController.swift
@@ -231,31 +231,18 @@ final class DFWindowController: NSWindowController {
   }
 
   private func promptNewWorktreeSession() {
-    let alert = NSAlert()
-    alert.messageText = "New Session with Worktree"
-    alert.informativeText = "Enter a branch name for the new worktree:"
-    alert.addButton(withTitle: "Create")
-    alert.addButton(withTitle: "Cancel")
-
-    let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-    input.placeholderString = "feature-name"
-    alert.accessoryView = input
-
     guard let win = window else { return }
-    alert.beginSheetModal(for: win) { response in
-      guard response == .alertFirstButtonReturn else { return }
-      let name = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !name.isEmpty else { return }
-
-      do {
-        let path = try WorktreeManager.shared.createWorktree(name: name)
-        self.terminalPane.createNewSession(name: name, worktreePath: path)
-      } catch {
-        let errAlert = NSAlert()
-        errAlert.messageText = "Worktree Error"
-        errAlert.informativeText = error.localizedDescription
-        errAlert.runModal()
-      }
+    NewWorktreeDialog.present(
+      on: win, title: "New Session with Worktree",
+      message: "Enter a branch name for the new worktree:"
+    ) { result in
+      guard
+        let path = NewWorktreeDialog.createWorktreeReportingErrors(
+          repoRoot: nil, name: result.name)
+      else { return }
+      self.terminalPane.createNewSession(
+        name: result.name, worktreePath: path,
+        initialPrompt: result.ticket.map(TicketLink.kickoffPrompt))
     }
   }
 

--- a/Sources/DraftFrameKit/NewWorktreeDialog.swift
+++ b/Sources/DraftFrameKit/NewWorktreeDialog.swift
@@ -1,0 +1,118 @@
+import AppKit
+
+/// The shared "create a worktree" sheet used by the sidebar buttons and the
+/// New Session with Worktree shortcut: a branch-name field plus an optional
+/// ticket link. Pasting a recognizable ticket URL auto-fills the name with a
+/// git-safe slug (until the user edits the name themselves), and the ticket
+/// becomes the new session's kickoff prompt.
+enum NewWorktreeDialog {
+  struct Result {
+    let name: String
+    /// Trimmed ticket link, nil when the field was left empty.
+    let ticket: String?
+  }
+
+  /// Presents the sheet on `window` and calls `completion` only when the
+  /// user confirms with a non-empty name.
+  static func present(
+    on window: NSWindow, title: String, message: String,
+    completion: @escaping (Result) -> Void
+  ) {
+    let alert = NSAlert()
+    alert.messageText = title
+    alert.informativeText = message
+    alert.addButton(withTitle: "Create")
+    alert.addButton(withTitle: "Cancel")
+
+    let accessory = AccessoryView()
+    alert.accessoryView = accessory
+    alert.window.initialFirstResponder = accessory.nameField
+
+    alert.beginSheetModal(for: window) { response in
+      guard response == .alertFirstButtonReturn else { return }
+      let name = accessory.nameField.stringValue
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !name.isEmpty else { return }
+      let ticket = accessory.ticketField.stringValue
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      completion(Result(name: name, ticket: ticket.isEmpty ? nil : ticket))
+    }
+  }
+
+  /// Runs a `WorktreeManager` create and wraps failures in the standard
+  /// "Worktree Error" alert; returns the worktree path on success.
+  static func createWorktreeReportingErrors(
+    repoRoot: String?, name: String, baseBranch: String? = nil
+  ) -> String? {
+    do {
+      if let root = repoRoot {
+        return try WorktreeManager.shared.createWorktree(
+          repoRoot: root, name: name, baseBranch: baseBranch)
+      }
+      return try WorktreeManager.shared.createWorktree(name: name, baseBranch: baseBranch)
+    } catch {
+      let errAlert = NSAlert()
+      errAlert.messageText = "Worktree Error"
+      errAlert.informativeText = error.localizedDescription
+      errAlert.runModal()
+      return nil
+    }
+  }
+
+  /// Name + ticket fields with the paste-to-autofill behavior.
+  private final class AccessoryView: NSView, NSTextFieldDelegate {
+    let nameField = NSTextField()
+    let ticketField = NSTextField()
+    /// Set once the user types in the name field directly; from then on the
+    /// ticket field stops overwriting their choice.
+    private var nameEditedByUser = false
+
+    init() {
+      super.init(frame: NSRect(x: 0, y: 0, width: 260, height: 76))
+
+      nameField.placeholderString = "feature-name"
+      ticketField.placeholderString = "Ticket link (optional)"
+      nameField.delegate = self
+      ticketField.delegate = self
+
+      let ticketLabel = NSTextField(labelWithString: "Ticket:")
+      let nameLabel = NSTextField(labelWithString: "Name:")
+      for label in [ticketLabel, nameLabel] {
+        label.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+        label.textColor = .secondaryLabelColor
+      }
+
+      for v in [nameLabel, nameField, ticketLabel, ticketField] {
+        v.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(v)
+      }
+      NSLayoutConstraint.activate([
+        nameLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+        nameLabel.centerYAnchor.constraint(equalTo: nameField.centerYAnchor),
+        ticketLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+        ticketLabel.centerYAnchor.constraint(equalTo: ticketField.centerYAnchor),
+        nameLabel.widthAnchor.constraint(equalTo: ticketLabel.widthAnchor),
+
+        nameField.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+        nameField.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 6),
+        nameField.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+        ticketField.topAnchor.constraint(equalTo: nameField.bottomAnchor, constant: 8),
+        ticketField.leadingAnchor.constraint(equalTo: nameField.leadingAnchor),
+        ticketField.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ticketField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+      ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been used") }
+
+    func controlTextDidChange(_ obj: Notification) {
+      guard let field = obj.object as? NSTextField else { return }
+      if field === nameField {
+        nameEditedByUser = !nameField.stringValue.isEmpty
+      } else if field === ticketField, !nameEditedByUser {
+        nameField.stringValue = TicketLink.suggestedName(from: ticketField.stringValue) ?? ""
+      }
+    }
+  }
+}

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -322,11 +322,13 @@ final class SessionManager {
 
   /// Create a new session and return it. `agent` defaults to the persisted
   /// agent preference; pass one explicitly to restore or restart a session
-  /// with the agent it originally launched with.
+  /// with the agent it originally launched with. `initialPrompt` is handed
+  /// to the agent CLI as a positional argument so the session starts working
+  /// on it immediately (used for ticket-linked worktrees).
   @discardableResult
   func createSession(
     name: String? = nil, command: String? = nil, worktreePath: String? = nil,
-    agent: AgentKind? = nil
+    agent: AgentKind? = nil, initialPrompt: String? = nil
   )
     -> Session
   {
@@ -398,7 +400,8 @@ final class SessionManager {
     // Resolve the agent command to an absolute path so we don't depend
     // on the spawned login shell re-sourcing PATH correctly.
     let agentBin = SessionManager.resolveAgentPath(agent: agent, augmentedPath: composedPath)
-    let agentCmd = agent.launchCommand(binPath: agentBin, modelId: modelId)
+    let agentCmd = agent.launchCommand(
+      binPath: agentBin, modelId: modelId, initialPrompt: initialPrompt)
 
     // Start transcript/status watchers for cost/token/state tracking.
     let watchDir = worktreePath ?? projectDir ?? FileManager.default.currentDirectoryPath
@@ -436,7 +439,7 @@ final class SessionManager {
     // render. The kernel buffers the bytes until the shell calls read(), so
     // we don't need a delay before sending.
     if let wtPath = worktreePath {
-      tv.send(txt: "cd \(wtPath) && clear && \(agentCmd)\r")
+      tv.send(txt: "cd \(shellSingleQuote(wtPath)) && clear && \(agentCmd)\r")
     } else {
       tv.send(txt: "clear && \(agentCmd)\r")
     }

--- a/Sources/DraftFrameKit/TicketLink.swift
+++ b/Sources/DraftFrameKit/TicketLink.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Derives worktree names and session kickoff prompts from pasted ticket
+/// links (Jira, Linear, GitHub issues/PRs, or a bare issue key). Parsing is
+/// purely lexical — no network, no credentials; the launched agent fetches
+/// the ticket itself with whatever tools it has.
+enum TicketLink {
+
+  /// Matches an issue key like `ENG-1234` (used both for bare-key input and
+  /// for picking keys out of URL components).
+  private static let keyPattern = try! NSRegularExpression(
+    pattern: #"^[A-Za-z][A-Za-z0-9]*-\d+$"#)
+
+  /// A git-safe worktree/branch name derived from `input`, or nil when
+  /// nothing name-worthy can be extracted. Accepts full ticket URLs or a
+  /// bare key like `ENG-1234`.
+  static func suggestedName(from input: String) -> String? {
+    let raw = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !raw.isEmpty else { return nil }
+
+    if isIssueKey(raw) { return slugify(raw) }
+
+    guard let url = URL(string: raw), let host = url.host?.lowercased() else { return nil }
+    let parts = url.pathComponents.filter { $0 != "/" && !$0.isEmpty }
+
+    // Jira: .../browse/ENG-1234 (also ?selectedIssue=ENG-1234 board links).
+    if let i = parts.firstIndex(of: "browse"), i + 1 < parts.count, isIssueKey(parts[i + 1]) {
+      return slugify(parts[i + 1])
+    }
+    if let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+      let selected = query.first(where: { $0.name == "selectedIssue" })?.value,
+      isIssueKey(selected)
+    {
+      return slugify(selected)
+    }
+
+    // Linear: /team/issue/ENG-1234/fix-login (key + slug as separate
+    // components) or the older /team/issue/eng-1234-fix-login.
+    if host.hasSuffix("linear.app"), let i = parts.firstIndex(of: "issue"), i + 1 < parts.count {
+      let key = parts[i + 1]
+      if isIssueKey(key), i + 2 < parts.count {
+        return slugify("\(key)-\(parts[i + 2])")
+      }
+      return slugify(key)
+    }
+
+    // GitHub: /owner/repo/issues/123 or /owner/repo/pull/123.
+    if host == "github.com", parts.count >= 4 {
+      if parts[2] == "issues", Int(parts[3]) != nil { return slugify("issue-\(parts[3])") }
+      if parts[2] == "pull", Int(parts[3]) != nil { return slugify("pr-\(parts[3])") }
+    }
+
+    // Unknown tracker: an issue key anywhere in the path, else the last
+    // path component if it slugs into something usable.
+    if let key = parts.first(where: isIssueKey) { return slugify(key) }
+    if let last = parts.last { return slugify(last) }
+    return nil
+  }
+
+  /// The first message a new session sends its agent so work on the ticket
+  /// starts immediately.
+  static func kickoffPrompt(ticket: String) -> String {
+    "Work on this ticket: \(ticket) . "
+      + "First read the ticket using the tools you have "
+      + "(gh for GitHub, or an MCP integration for Jira/Linear), "
+      + "then briefly state your plan and implement it."
+  }
+
+  private static func isIssueKey(_ s: String) -> Bool {
+    keyPattern.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
+  }
+
+  /// Lowercase and reduce to `[a-z0-9-]` so the result is legal as both a
+  /// git branch name and a directory name; capped so pasted long titles
+  /// don't produce unwieldy branches.
+  private static func slugify(_ s: String) -> String? {
+    var out = ""
+    for ch in s.lowercased() {
+      if ch.isLetter && ch.isASCII || ch.isNumber && ch.isASCII {
+        out.append(ch)
+      } else if !out.isEmpty && out.last != "-" {
+        out.append("-")
+      }
+    }
+    while out.last == "-" { out.removeLast() }
+    if out.count > 40 {
+      out = String(out.prefix(40))
+      while out.last == "-" { out.removeLast() }
+    }
+    return out.isEmpty ? nil : out
+  }
+}
+
+/// Quote a string so it survives verbatim inside a single-line shell command.
+func shellSingleQuote(_ s: String) -> String {
+  "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}

--- a/Tests/DraftFrameTests/TicketLinkTests.swift
+++ b/Tests/DraftFrameTests/TicketLinkTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+final class TicketLinkTests: XCTestCase {
+
+  func testJiraBrowseURL() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(from: "https://calm.atlassian.net/browse/ENG-1234"),
+      "eng-1234")
+  }
+
+  func testJiraBoardSelectedIssueURL() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(
+        from: "https://calm.atlassian.net/jira/software/projects/ENG/boards/1?selectedIssue=ENG-42"
+      ),
+      "eng-42")
+  }
+
+  func testLinearKeyPlusSlugURL() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(from: "https://linear.app/calm/issue/ENG-1234/fix-login-flow"),
+      "eng-1234-fix-login-flow")
+  }
+
+  func testLinearCombinedSlugURL() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(from: "https://linear.app/calm/issue/eng-1234-fix-login"),
+      "eng-1234-fix-login")
+  }
+
+  func testGitHubIssueURL() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(from: "https://github.com/calm/app/issues/987"),
+      "issue-987")
+  }
+
+  func testGitHubPullURL() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(from: "https://github.com/calm/app/pull/55"),
+      "pr-55")
+  }
+
+  func testBareIssueKey() {
+    XCTAssertEqual(TicketLink.suggestedName(from: "ENG-1234"), "eng-1234")
+    XCTAssertEqual(TicketLink.suggestedName(from: "  ENG-1234  "), "eng-1234")
+  }
+
+  func testUnknownTrackerFallsBackToLastPathComponent() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(from: "https://tracker.example.com/tickets/fix-the-thing"),
+      "fix-the-thing")
+  }
+
+  func testUnknownTrackerPrefersIssueKeyInPath() {
+    XCTAssertEqual(
+      TicketLink.suggestedName(from: "https://tracker.example.com/ENG-77/some-long-title"),
+      "eng-77")
+  }
+
+  func testEmptyAndGarbageInput() {
+    XCTAssertNil(TicketLink.suggestedName(from: ""))
+    XCTAssertNil(TicketLink.suggestedName(from: "   "))
+    XCTAssertNil(TicketLink.suggestedName(from: "://"))
+  }
+
+  func testSlugIsCappedAndCleaned() {
+    let long =
+      "https://linear.app/calm/issue/ENG-1/"
+      + "a-very-long-title-that-keeps-going-and-going-and-going-forever"
+    let name = TicketLink.suggestedName(from: long)
+    XCTAssertNotNil(name)
+    XCTAssertLessThanOrEqual(name!.count, 40)
+    XCTAssertFalse(name!.hasSuffix("-"))
+  }
+
+  func testKickoffPromptContainsTicket() {
+    let prompt = TicketLink.kickoffPrompt(ticket: "https://calm.atlassian.net/browse/ENG-1")
+    XCTAssertTrue(prompt.contains("https://calm.atlassian.net/browse/ENG-1"))
+  }
+
+  func testShellSingleQuote() {
+    XCTAssertEqual(shellSingleQuote("plain"), "'plain'")
+    XCTAssertEqual(shellSingleQuote("it's"), "'it'\\''s'")
+  }
+}


### PR DESCRIPTION
## Summary
- All three worktree entry points (sidebar +, "New Worktree from Here", Cmd+N "New Session with Worktree") now share a two-field dialog: branch name plus an optional ticket link
- Pasting a Jira, Linear, or GitHub issue/PR URL (or a bare key like ENG-1234) auto-fills a git-safe worktree name until the user edits the name themselves
- When a ticket is provided, the new session launches the agent with an initial kickoff prompt so it immediately reads the ticket and starts working on it
- Parsing is purely lexical (no network, no credentials); the agent fetches ticket details itself via gh or its MCP integrations
- The prompt and the worktree path in the session bootstrap line are now shell-escaped

## Test plan
- 13 new unit tests in TicketLinkTests covering Jira browse and board URLs, both Linear URL styles, GitHub issues/PRs, bare keys, unknown-tracker fallbacks, garbage input, slug capping, and shell quoting
- Full suite passes, swift-format lint clean
- Manual: create a worktree from each entry point with and without a ticket link

<img width="295" height="230" alt="Screenshot 2026-08-03 at 12 00 56 PM" src="https://github.com/user-attachments/assets/a0fcbb06-489f-4d24-934d-37ca55aa6c4c" />