### PR TITLE
Multi-terminal quick terminal: tabs, splits, and Option-key shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Grab the latest DMG from [GitHub Releases](https://github.com/intuitive-compute/
 - **Code editor** — Built-in file inspector with syntax highlighting (Cmd+E)
 - **Configurable toolkit** — One-click commands (test, build, lint) with output popovers
 - **Voice transcription** — On-device speech-to-text via Apple Speech (Cmd+Shift+V)
+- **Quick terminal** — Floating per-session shell (Cmd+`) with tabs and tmux-style recursive splits
 - **Dashboard** — Full-screen session overview (Cmd+D)
 - **Session persistence** — Restore sessions across app restarts
 - **Keyboard shortcuts** — Cmd+T/W/1-9/D/N/O/E/` and more
@@ -64,7 +65,24 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for DMG packaging, signing, and notarizatio
 | Cmd+N | New session with worktree |
 | Cmd+O | Open project |
 | Cmd+Shift+V | Voice input |
-| Cmd+` | Toggle quick terminal (floating shell in the project directory) |
+| Cmd+` | Toggle quick terminal (floating shell in the session's worktree) |
+
+### Quick Terminal
+
+Each session's quick terminal supports multiple terminals: tabs, plus recursive splits within each tab. Tabs are numbered by position and renumber as they close, always matching Option+1-9. Session tabs and cards in the main window show their Cmd+1-9 number the same way.
+
+These shortcuts are active while the quick terminal is focused:
+
+| Shortcut | Action |
+|----------|--------|
+| Option+T | New tab |
+| Option+D | Split focused pane side-by-side |
+| Option+Shift+D | Split focused pane stacked |
+| Option+W | Close focused pane |
+| Option+Shift+W | Close tab |
+| Option+1-9 | Jump to tab N |
+
+The focused pane carries a light accent outline when a tab is split; click any pane to move focus.
 
 ## Architecture
 

--- a/Sources/DraftFrameKit/DFQuickTerminal.swift
+++ b/Sources/DraftFrameKit/DFQuickTerminal.swift
@@ -2,27 +2,36 @@ import AppKit
 import SwiftTerm
 
 /// Floating quick-terminal window. Toggled with Cmd+` (backtick). Each
-/// session tab owns its own shell — switching tabs swaps which terminal
-/// view is mounted in the single floating window. Shells persist across
-/// show/hide and across session switches, so scrollback and in-flight
-/// commands survive a toggle.
+/// session owns its own set of tabs, and each tab owns its own tree of
+/// terminal splits — switching sessions swaps in that session's own
+/// tabs/splits, switching tabs/panes swaps which part of that tree is
+/// visible/focused. Shells persist across show/hide, tab switches, and
+/// session switches, so scrollback and in-flight commands survive all of
+/// that until the shell itself exits.
 final class DFQuickTerminal {
   static let shared = DFQuickTerminal()
 
   private var window: NSWindow?
   private var container: NSView?
-  private var terminals: [UUID: ClaudeTerminalView] = [:]
+  private var sessionStates: [UUID: QTSessionState] = [:]
   private var currentlyInstalledSessionID: UUID?
+  private var clickMonitor: Any?
 
-  /// In-flight loading state for sessions whose shell is still booting.
-  /// Present only while a fresh shell renders its banner and runs the
-  /// `cd && clear` bootstrap; cleared once the shell settles.
+  /// Wrapper views for the panes currently on screen, keyed by pane id —
+  /// rebuilt every time the visible tab's tree is rebuilt. Used to toggle the
+  /// focus-highlight border without a full rebuild.
+  private var paneWrappers: [UUID: NSView] = [:]
+
+  /// In-flight loading state for panes whose shell is still booting. Present
+  /// only while a fresh shell renders its banner and runs the `cd && clear`
+  /// bootstrap; cleared once the shell settles.
   private var loads: [UUID: LoadState] = [:]
 
   /// Tracks one booting shell: the overlay shown over it, the timers that
   /// decide when it's settled, and the rolling scan for the ready marker.
   private final class LoadState {
     let overlay: TerminalLoadingOverlay
+    let terminalView: ClaudeTerminalView
     var settleTimer: Timer?
     var maxTimer: Timer?
     /// True once the invisible ready marker has been observed in the PTY
@@ -31,12 +40,18 @@ final class DFQuickTerminal {
     var sawMarker = false
     /// Rolling window of recent printable bytes, scanned for the marker.
     var scanBuffer = ""
-    init(overlay: TerminalLoadingOverlay) { self.overlay = overlay }
+    init(overlay: TerminalLoadingOverlay, terminalView: ClaudeTerminalView) {
+      self.overlay = overlay
+      self.terminalView = terminalView
+    }
   }
 
   /// Container inset matching the transparent titlebar so content doesn't
   /// render behind the traffic lights.
   private static let titlebarInset: CGFloat = 28
+
+  /// Height of the per-session tab strip.
+  private static let tabBarHeight: CGFloat = 24
 
   /// Token emitted (invisibly, inside an OSC sequence) by the bootstrap once
   /// the shell is ready. Split across printf's format and argument so the
@@ -65,6 +80,12 @@ final class DFQuickTerminal {
       object: nil)
   }
 
+  /// Whether the popup terminal is currently the key window — used to scope
+  /// its tab/split shortcuts so they only fire while it's focused.
+  var isFocused: Bool {
+    window?.isKeyWindow == true
+  }
+
   /// Show the quick terminal if hidden, hide it if currently visible and key.
   /// If visible but not key (user clicked the main window), re-focus it
   /// instead of hiding — avoids requiring a double Cmd+` to get it back.
@@ -91,8 +112,7 @@ final class DFQuickTerminal {
       // No session to attach to — quick terminal is session-scoped.
       return
     }
-    let tv = terminal(for: active)
-    install(tv, for: active)
+    install(for: active)
     positionAtTop(of: win)
     win.makeKeyAndOrderFront(nil)
     NSApp.activate(ignoringOtherApps: true)
@@ -131,66 +151,170 @@ final class DFQuickTerminal {
 
     self.container = container
     self.window = win
+    installClickTracking()
   }
 
-  // MARK: - Per-session terminal lifecycle
+  /// Track which pane the user last clicked, independent of (and in
+  /// addition to) AppKit's own click-to-focus promotion. `paneWrapper`'s
+  /// terminal is inset a couple of points inside each wrapper, and with
+  /// nested `NSSplitView`s in between, relying solely on implicit
+  /// first-responder promotion left our own bookkeeping (which pane is
+  /// "focused" for the border highlight and for Option+W/split targeting)
+  /// stale whenever the user clicked a pane we hadn't programmatically
+  /// focused ourselves. This explicitly re-syncs both on every click.
+  private func installClickTracking() {
+    guard clickMonitor == nil else { return }
+    clickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
+      self?.handleClick(event)
+      return event
+    }
+  }
 
-  /// Return the cached terminal view for `session`, lazy-creating and
-  /// starting a fresh shell rooted at the session's worktree if none exists.
-  private func terminal(for session: Session) -> ClaudeTerminalView {
-    if let existing = terminals[session.id] {
+  private func handleClick(_ event: NSEvent) {
+    guard let win = window, event.window === win,
+      let sessionID = currentlyInstalledSessionID,
+      let state = sessionStates[sessionID],
+      let tab = state.activeTab
+    else { return }
+    let windowPoint = event.locationInWindow
+    for pane in tab.allPanes() {
+      guard let wrapper = paneWrappers[pane.id] else { continue }
+      let localPoint = wrapper.convert(windowPoint, from: nil)
+      if wrapper.bounds.contains(localPoint) {
+        focusPane(pane, in: tab)
+        return
+      }
+    }
+  }
+
+  // MARK: - Per-session state lifecycle
+
+  /// Return the state for `session`, lazy-creating a single tab with a
+  /// single terminal (today's default) if none exists yet.
+  private func sessionState(for session: Session) -> QTSessionState {
+    if let existing = sessionStates[session.id] {
       return existing
     }
-    let tv = ClaudeTerminalView(frame: .zero)
-    tv.translatesAutoresizingMaskIntoConstraints = false
-    tv.nativeForegroundColor = Theme.text1
-    tv.nativeBackgroundColor = Theme.bg
-    tv.selectedTextBackgroundColor = Theme.selected
-    tv.caretColor = Theme.accent
-    tv.font = Theme.terminalMono(13)
-
-    let sessionID = session.id
-    tv.onProcessExit = { [weak self] _ in
-      DispatchQueue.main.async { self?.handleProcessExit(for: sessionID) }
-    }
-
-    terminals[session.id] = tv
-
-    // Cover the booting shell with a loading overlay until it settles. The
-    // overlay is mounted by install() and torn down by finishLoading().
-    let overlay = TerminalLoadingOverlay(message: "Starting terminal…", style: .zoom)
-    overlay.translatesAutoresizingMaskIntoConstraints = false
-    loads[session.id] = LoadState(overlay: overlay)
-
     let dir = session.worktreePath ?? SessionManager.shared.projectDir
-    startShell(in: tv, for: session, workingDirectory: dir)
-    return tv
+    let pane = makePane(sessionID: session.id, workingDirectory: dir)
+    let state = QTSessionState()
+    state.tabs = [QTTab(pane: pane)]
+    sessionStates[session.id] = state
+    return state
   }
 
-  /// Mount `tv` in the floating window's container, replacing whatever was
-  /// previously shown. No-op if `tv` is already the installed view.
-  private func install(_ tv: ClaudeTerminalView, for session: Session) {
-    guard let container = container else { return }
-    if currentlyInstalledSessionID == session.id, tv.superview === container {
+  /// Ensure `session`'s state exists and is on screen. No-op (besides the
+  /// window title) if it's already the installed session.
+  private func install(for session: Session) {
+    _ = sessionState(for: session)
+    if currentlyInstalledSessionID == session.id {
       window?.title = "Quick Terminal — \(session.displayName)"
       return
     }
-    // Drop any currently installed view (don't tear down its shell —
-    // we want to swap back to it later with state intact).
-    for sub in container.subviews { sub.removeFromSuperview() }
+    rebuildContent(for: session)
+  }
 
-    container.addSubview(tv)
+  /// Tear down and rebuild the window's content to reflect `session`'s
+  /// active tab. Terminal views are reused by reference — only their
+  /// superview changes — so scrollback/pty state always survives this.
+  private func rebuildContent(for session: Session) {
+    guard let container = container,
+      let state = sessionStates[session.id],
+      let tab = state.activeTab
+    else { return }
+
+    for sub in container.subviews { sub.removeFromSuperview() }
+    paneWrappers.removeAll()
+
+    let tabBar = buildTabBar(for: state)
+    let content = buildView(for: tab.root)
+    content.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(tabBar)
+    container.addSubview(content)
+
     NSLayoutConstraint.activate([
-      tv.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.titlebarInset),
-      tv.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
-      tv.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
-      tv.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8),
+      tabBar.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.titlebarInset),
+      tabBar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      tabBar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      tabBar.heightAnchor.constraint(equalToConstant: Self.tabBarHeight),
+
+      content.topAnchor.constraint(equalTo: tabBar.bottomAnchor, constant: 4),
+      content.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
+      content.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+      content.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8),
     ])
 
-    // If this shell is still booting, lay its loading overlay on top of the
-    // terminal (added after `tv`, so it's above it in z-order).
-    if let overlay = loads[session.id]?.overlay {
-      container.addSubview(overlay)
+    updateFocusBorders(for: tab)
+    currentlyInstalledSessionID = session.id
+    window?.title = "Quick Terminal — \(session.displayName)"
+
+    // NSSplitView doesn't distribute space evenly among arranged subviews by
+    // default — it sizes them off their fitting size, which our plain
+    // terminal wrappers don't provide. Force every divider to the midpoint
+    // once real frames exist. Split views are rebuilt from scratch here, so
+    // this always resets to 50/50 rather than remembering a prior manual
+    // drag — acceptable since nothing in the model persists divider ratios
+    // across rebuilds anyway (tab switches, other splits/closes) today.
+    container.layoutSubtreeIfNeeded()
+    equalizeSplitPositions(in: content)
+  }
+
+  /// Recursively center every split divider in `view`'s subtree, laying out
+  /// outer splits before descending so nested splits see their real (i.e.
+  /// post-divider-move) bounds.
+  private func equalizeSplitPositions(in view: NSView) {
+    guard let splitView = view as? NSSplitView else { return }
+    splitView.layoutSubtreeIfNeeded()
+    let total = splitView.isVertical ? splitView.bounds.width : splitView.bounds.height
+    let half = (total - splitView.dividerThickness) / 2
+    if half > 0 {
+      splitView.setPosition(half, ofDividerAt: 0)
+      splitView.layoutSubtreeIfNeeded()
+    }
+    for sub in splitView.arrangedSubviews {
+      equalizeSplitPositions(in: sub)
+    }
+  }
+
+  /// Recursively build the view tree for a split node: a leaf becomes a
+  /// bordered wrapper around its terminal, a split becomes an NSSplitView
+  /// dividing its children.
+  private func buildView(for node: QTNode) -> NSView {
+    switch node {
+    case .leaf(let pane):
+      return paneWrapper(pane)
+    case .split(let direction, let children):
+      let splitView = NSSplitView()
+      splitView.translatesAutoresizingMaskIntoConstraints = false
+      splitView.isVertical = (direction == .vertical)
+      splitView.dividerStyle = .thin
+      for child in children {
+        splitView.addArrangedSubview(buildView(for: child))
+      }
+      return splitView
+    }
+  }
+
+  private func paneWrapper(_ pane: QTPane) -> NSView {
+    let wrapper = NSView()
+    wrapper.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.wantsLayer = true
+    wrapper.layer?.cornerRadius = 4
+    wrapper.layer?.borderWidth = 2
+    wrapper.layer?.borderColor = NSColor.clear.cgColor
+
+    let tv = pane.terminalView
+    wrapper.addSubview(tv)
+    NSLayoutConstraint.activate([
+      tv.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: 2),
+      tv.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor, constant: 2),
+      tv.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor, constant: -2),
+      tv.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor, constant: -2),
+    ])
+
+    // If this shell is still booting, lay its loading overlay on top.
+    if let overlay = loads[pane.id]?.overlay {
+      wrapper.addSubview(overlay)
       NSLayoutConstraint.activate([
         overlay.topAnchor.constraint(equalTo: tv.topAnchor),
         overlay.leadingAnchor.constraint(equalTo: tv.leadingAnchor),
@@ -199,32 +323,362 @@ final class DFQuickTerminal {
       ])
     }
 
-    currentlyInstalledSessionID = session.id
-    window?.title = "Quick Terminal — \(session.displayName)"
+    paneWrappers[pane.id] = wrapper
+    return wrapper
   }
 
-  /// Make the installed session's terminal the first responder — unless it's
-  /// still booting, in which case focus its loading overlay so typed-ahead
-  /// keystrokes are swallowed rather than corrupting the bootstrap command.
-  private func focusInstalledContent() {
-    guard let win = window, let id = currentlyInstalledSessionID else { return }
-    if let overlay = loads[id]?.overlay {
-      win.makeFirstResponder(overlay)
-    } else if let tv = terminals[id] {
-      win.makeFirstResponder(tv)
+  /// Give the focused pane's wrapper a visible accent border — only shown
+  /// once there's more than one pane, since a single terminal doesn't need
+  /// a "this one is active" cue.
+  private func updateFocusBorders(for tab: QTTab) {
+    let panes = tab.allPanes()
+    let showBorders = panes.count > 1
+    for pane in panes {
+      guard let wrapper = paneWrappers[pane.id] else { continue }
+      let isFocused = showBorders && pane.id == tab.lastFocusedPaneID
+      wrapper.layer?.borderColor =
+        isFocused ? Theme.accent.withAlphaComponent(0.7).cgColor : NSColor.clear.cgColor
     }
   }
 
-  /// Called when a session's quick-terminal shell exits (user typed `exit`).
-  /// Drop the cached view; if it was the visible one, hide the window so
-  /// the next Cmd+` for that session lazy-rebuilds a fresh shell.
-  private func handleProcessExit(for sessionID: UUID) {
-    terminals.removeValue(forKey: sessionID)
-    cancelLoading(for: sessionID)
-    if currentlyInstalledSessionID == sessionID {
-      currentlyInstalledSessionID = nil
-      for sub in container?.subviews ?? [] { sub.removeFromSuperview() }
-      window?.orderOut(nil)
+  /// Make the installed session's focused pane the first responder — unless
+  /// it's still booting, in which case focus its loading overlay so
+  /// typed-ahead keystrokes are swallowed rather than corrupting the
+  /// bootstrap command.
+  private func focusInstalledContent() {
+    guard let sessionID = currentlyInstalledSessionID,
+      let state = sessionStates[sessionID],
+      let tab = state.activeTab,
+      let pane = tab.focusedPane()
+    else { return }
+    focusPaneOrOverlay(pane)
+  }
+
+  private func focusPaneOrOverlay(_ pane: QTPane) {
+    // Deferred to the next runloop tick: calling makeFirstResponder in the
+    // same turn as a split/tab rebuild races NSSplitView's own post-layout
+    // bookkeeping, which can silently steal first responder back right
+    // after we set it. Letting the current turn finish first makes the
+    // assignment stick.
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self, let win = self.window else { return }
+      if let overlay = self.loads[pane.id]?.overlay {
+        win.makeFirstResponder(overlay)
+      } else {
+        win.makeFirstResponder(pane.terminalView)
+      }
+    }
+  }
+
+  /// Focus `pane` within `tab`: record it as the tab's last-focused pane,
+  /// refresh the highlight border, and move first responder to it.
+  private func focusPane(_ pane: QTPane, in tab: QTTab) {
+    tab.lastFocusedPaneID = pane.id
+    updateFocusBorders(for: tab)
+    focusPaneOrOverlay(pane)
+  }
+
+  /// The pane the user was last interacting with in `tab`, preferring
+  /// whatever AppKit currently reports as first responder (i.e. wherever the
+  /// user just clicked) over the tab's last recorded focus.
+  private func currentFocusedPane(in tab: QTTab) -> QTPane? {
+    if let responder = window?.firstResponder as? NSView,
+      let match = tab.allPanes().first(where: { $0.terminalView === responder })
+    {
+      tab.lastFocusedPaneID = match.id
+      return match
+    }
+    return tab.focusedPane()
+  }
+
+  private func session(withID id: UUID) -> Session? {
+    SessionManager.shared.sessions.first { $0.id == id }
+  }
+
+  // MARK: - Tab/split actions (driven by shortcuts and tab-bar buttons)
+
+  /// Add a new tab (with a single fresh terminal) to the active session and
+  /// switch to it.
+  func addTab() {
+    guard let session = SessionManager.shared.activeSession else { return }
+    let state = sessionState(for: session)
+    let dir = session.worktreePath ?? SessionManager.shared.projectDir
+    let pane = makePane(sessionID: session.id, workingDirectory: dir)
+    let tab = QTTab(pane: pane)
+    state.tabs.append(tab)
+    state.activeTabIndex = state.tabs.count - 1
+    rebuildContent(for: session)
+    focusPane(pane, in: tab)
+  }
+
+  /// Split the active tab's focused pane, inserting a fresh terminal
+  /// alongside it.
+  func splitFocusedPane(_ direction: QTSplitDirection) {
+    guard let session = SessionManager.shared.activeSession,
+      let state = sessionStates[session.id],
+      let tab = state.activeTab,
+      let focused = currentFocusedPane(in: tab)
+    else { return }
+    let dir = session.worktreePath ?? SessionManager.shared.projectDir
+    let newPane = makePane(sessionID: session.id, workingDirectory: dir)
+    tab.split(paneID: focused.id, direction: direction, newPane: newPane)
+    rebuildContent(for: session)
+    focusPane(newPane, in: tab)
+  }
+
+  /// Close the active tab's focused pane: kill its shell and remove it from
+  /// the tree immediately.
+  func closeFocusedPane() {
+    guard let session = SessionManager.shared.activeSession,
+      let state = sessionStates[session.id],
+      let tab = state.activeTab,
+      let focused = currentFocusedPane(in: tab)
+    else { return }
+    killShell(focused.terminalView)
+    removePane(paneID: focused.id, sessionID: session.id)
+  }
+
+  /// Close the active tab and every pane in it — the keyboard equivalent of
+  /// clicking the tab's × button.
+  func closeActiveTab() {
+    guard let session = SessionManager.shared.activeSession,
+      let state = sessionStates[session.id],
+      let tab = state.activeTab
+    else { return }
+    closeTab(tabID: tab.id, sessionID: session.id)
+  }
+
+  /// Close `tabID`: kill every pane's shell, drop the tab, and re-render.
+  private func closeTab(tabID: UUID, sessionID: UUID) {
+    guard let state = sessionStates[sessionID],
+      let tabIndex = state.tabs.firstIndex(where: { $0.id == tabID })
+    else { return }
+    for pane in state.tabs[tabIndex].allPanes() {
+      cancelLoading(for: pane.id)
+      paneWrappers.removeValue(forKey: pane.id)
+      killShell(pane.terminalView)
+    }
+    state.tabs.remove(at: tabIndex)
+    if state.activeTabIndex >= tabIndex {
+      state.activeTabIndex = max(0, state.activeTabIndex - 1)
+    }
+    finishRemoval(sessionID: sessionID, state: state)
+  }
+
+  /// Kill a pane's shell. SwiftTerm's `terminate()` alone is not enough for a
+  /// programmatic close: it sends SIGTERM, which interactive shells ignore,
+  /// and it cancels its process-exit monitor without firing
+  /// `processTerminated` — so the exit callback never arrives. Detach the
+  /// callback (the caller removes the pane itself) and follow up with SIGHUP,
+  /// which shells honor as "your terminal went away".
+  private func killShell(_ tv: ClaudeTerminalView) {
+    tv.onProcessExit = nil
+    let pid = tv.process?.shellPid ?? 0
+    tv.terminate()
+    if pid > 0 {
+      kill(pid, SIGHUP)
+    }
+  }
+
+  /// Switch to tab `index` (0-based) in the active session — Option+1-9.
+  /// Tabs only; panes within a tab are reached by click.
+  func jumpTo(index: Int) {
+    guard let session = SessionManager.shared.activeSession,
+      let state = sessionStates[session.id],
+      state.tabs.indices.contains(index)
+    else { return }
+    if state.activeTabIndex != index {
+      state.activeTabIndex = index
+      rebuildContent(for: session)
+    }
+    let tab = state.tabs[index]
+    if let pane = tab.focusedPane() {
+      focusPane(pane, in: tab)
+    }
+  }
+
+  // MARK: - Tab bar
+
+  /// NSButton carrying the id of the tab it represents, so a single action
+  /// method can dispatch on whichever tab was clicked.
+  private final class QTTabButton: NSButton {
+    var tabID = UUID()
+  }
+
+  private func buildTabBar(for state: QTSessionState) -> NSView {
+    let bar = NSView()
+    bar.translatesAutoresizingMaskIntoConstraints = false
+
+    let stack = NSStackView()
+    stack.orientation = .horizontal
+    stack.spacing = 4
+    stack.alignment = .centerY
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    bar.addSubview(stack)
+
+    let canClose = state.tabs.count > 1
+    for (i, tab) in state.tabs.enumerated() {
+      let isActive = i == state.activeTabIndex
+
+      let tabContainer = NSView()
+      tabContainer.translatesAutoresizingMaskIntoConstraints = false
+      tabContainer.wantsLayer = true
+      tabContainer.layer?.cornerRadius = 4
+      tabContainer.layer?.backgroundColor =
+        isActive ? Theme.surface2.cgColor : NSColor.clear.cgColor
+      tabContainer.layer?.borderColor =
+        isActive ? Theme.accent.withAlphaComponent(0.5).cgColor : NSColor.clear.cgColor
+      tabContainer.layer?.borderWidth = 1
+
+      let nameBtn = QTTabButton(title: "", target: self, action: #selector(tabClicked(_:)))
+      nameBtn.tabID = tab.id
+      nameBtn.translatesAutoresizingMaskIntoConstraints = false
+      nameBtn.isBordered = false
+      let attrs: [NSAttributedString.Key: Any] = [
+        .font: Theme.mono(11, weight: isActive ? .medium : .regular),
+        .foregroundColor: isActive ? Theme.text1 : Theme.text3,
+      ]
+      nameBtn.attributedTitle = NSAttributedString(string: " \(i + 1) ", attributes: attrs)
+      if i < 9 {
+        nameBtn.toolTip = "Switch to tab (\u{2325}\(i + 1))"
+      }
+      tabContainer.addSubview(nameBtn)
+
+      let closeBtn = QTTabButton(
+        title: "\u{00D7}", target: self, action: #selector(closeTabClicked(_:)))
+      closeBtn.tabID = tab.id
+      closeBtn.translatesAutoresizingMaskIntoConstraints = false
+      closeBtn.isBordered = false
+      closeBtn.font = Theme.mono(10)
+      closeBtn.contentTintColor = Theme.text3
+      closeBtn.toolTip = "Close tab"
+      closeBtn.isHidden = !canClose
+      tabContainer.addSubview(closeBtn)
+
+      NSLayoutConstraint.activate([
+        tabContainer.heightAnchor.constraint(equalToConstant: Self.tabBarHeight - 4),
+
+        nameBtn.leadingAnchor.constraint(equalTo: tabContainer.leadingAnchor),
+        nameBtn.topAnchor.constraint(equalTo: tabContainer.topAnchor),
+        nameBtn.bottomAnchor.constraint(equalTo: tabContainer.bottomAnchor),
+
+        closeBtn.leadingAnchor.constraint(equalTo: nameBtn.trailingAnchor, constant: -2),
+        closeBtn.trailingAnchor.constraint(equalTo: tabContainer.trailingAnchor, constant: -2),
+        closeBtn.topAnchor.constraint(equalTo: tabContainer.topAnchor),
+        closeBtn.bottomAnchor.constraint(equalTo: tabContainer.bottomAnchor),
+        closeBtn.widthAnchor.constraint(equalToConstant: 16),
+      ])
+
+      stack.addArrangedSubview(tabContainer)
+    }
+
+    let addBtn = NSButton(title: "+", target: self, action: #selector(addTabClicked(_:)))
+    addBtn.translatesAutoresizingMaskIntoConstraints = false
+    addBtn.isBordered = false
+    addBtn.font = Theme.mono(13)
+    addBtn.contentTintColor = Theme.text3
+    addBtn.toolTip = "New tab (\u{2325}T)"
+    bar.addSubview(addBtn)
+
+    NSLayoutConstraint.activate([
+      stack.leadingAnchor.constraint(equalTo: bar.leadingAnchor, constant: 6),
+      stack.centerYAnchor.constraint(equalTo: bar.centerYAnchor),
+      stack.trailingAnchor.constraint(lessThanOrEqualTo: addBtn.leadingAnchor, constant: -6),
+
+      addBtn.trailingAnchor.constraint(equalTo: bar.trailingAnchor, constant: -6),
+      addBtn.centerYAnchor.constraint(equalTo: bar.centerYAnchor),
+    ])
+
+    return bar
+  }
+
+  @objc private func tabClicked(_ sender: QTTabButton) {
+    guard let session = SessionManager.shared.activeSession,
+      let state = sessionStates[session.id],
+      let idx = state.tabs.firstIndex(where: { $0.id == sender.tabID })
+    else { return }
+    state.activeTabIndex = idx
+    rebuildContent(for: session)
+    if let pane = state.tabs[idx].focusedPane() {
+      focusPane(pane, in: state.tabs[idx])
+    }
+  }
+
+  @objc private func closeTabClicked(_ sender: QTTabButton) {
+    guard let sessionID = currentlyInstalledSessionID else { return }
+    closeTab(tabID: sender.tabID, sessionID: sessionID)
+  }
+
+  @objc private func addTabClicked(_ sender: NSButton) {
+    addTab()
+  }
+
+  // MARK: - Pane lifecycle
+
+  /// Build a fresh terminal pane and start its shell.
+  private func makePane(sessionID: UUID, workingDirectory: String?) -> QTPane {
+    let tv = ClaudeTerminalView(frame: .zero)
+    tv.translatesAutoresizingMaskIntoConstraints = false
+    tv.nativeForegroundColor = Theme.text1
+    tv.nativeBackgroundColor = Theme.bg
+    tv.selectedTextBackgroundColor = Theme.selected
+    tv.caretColor = Theme.accent
+    tv.font = Theme.terminalMono(13)
+
+    let pane = QTPane(terminalView: tv)
+    let paneID = pane.id
+    tv.onProcessExit = { [weak self] _ in
+      DispatchQueue.main.async { self?.removePane(paneID: paneID, sessionID: sessionID) }
+    }
+
+    // Cover the booting shell with a loading overlay until it settles. The
+    // overlay is mounted by paneWrapper() and torn down by finishLoading().
+    let overlay = TerminalLoadingOverlay(message: "Starting terminal…", style: .zoom)
+    overlay.translatesAutoresizingMaskIntoConstraints = false
+    loads[paneID] = LoadState(overlay: overlay, terminalView: tv)
+
+    startShell(in: tv, paneID: paneID, workingDirectory: workingDirectory)
+    return pane
+  }
+
+  /// Remove a pane from its tab: on a shell exit (user typed `exit`, whose
+  /// process-exit callback lands here) or after a programmatic close (whose
+  /// caller already killed the shell). Drops the tab if it's now empty.
+  private func removePane(paneID: UUID, sessionID: UUID) {
+    cancelLoading(for: paneID)
+    paneWrappers.removeValue(forKey: paneID)
+    guard let state = sessionStates[sessionID],
+      let tabIndex = state.tabIndex(ofPane: paneID)
+    else { return }
+
+    if state.tabs[tabIndex].remove(paneID: paneID) {
+      state.tabs.remove(at: tabIndex)
+      if state.activeTabIndex >= tabIndex {
+        state.activeTabIndex = max(0, state.activeTabIndex - 1)
+      }
+    }
+    finishRemoval(sessionID: sessionID, state: state)
+  }
+
+  /// Shared tail of pane/tab removal: drop the whole session state when its
+  /// last tab closed (hiding the window if it was the visible session),
+  /// otherwise re-render and hand focus back to the surviving focused pane
+  /// so typing continues without an extra click.
+  private func finishRemoval(sessionID: UUID, state: QTSessionState) {
+    if state.tabs.isEmpty {
+      sessionStates.removeValue(forKey: sessionID)
+      if currentlyInstalledSessionID == sessionID {
+        currentlyInstalledSessionID = nil
+        for sub in container?.subviews ?? [] { sub.removeFromSuperview() }
+        window?.orderOut(nil)
+      }
+      return
+    }
+    if currentlyInstalledSessionID == sessionID, let session = session(withID: sessionID) {
+      rebuildContent(for: session)
+      if window?.isVisible == true {
+        focusInstalledContent()
+      }
     }
   }
 
@@ -241,18 +695,26 @@ final class DFQuickTerminal {
       win.orderOut(nil)
       return
     }
-    let tv = terminal(for: active)
-    install(tv, for: active)
+    install(for: active)
     focusInstalledContent()
   }
 
   @objc private func sessionsDidChange() {
-    // Drop cached terminal views for sessions that no longer exist.
+    // Drop cached state for sessions that no longer exist, killing their
+    // shells so closed sessions don't leak background processes.
     let liveIDs = Set(SessionManager.shared.sessions.map(\.id))
-    let orphaned = terminals.keys.filter { !liveIDs.contains($0) }
+    let orphaned = sessionStates.keys.filter { !liveIDs.contains($0) }
     for id in orphaned {
-      terminals.removeValue(forKey: id)
-      cancelLoading(for: id)
+      if let state = sessionStates[id] {
+        for tab in state.tabs {
+          for pane in tab.allPanes() {
+            cancelLoading(for: pane.id)
+            paneWrappers.removeValue(forKey: pane.id)
+            killShell(pane.terminalView)
+          }
+        }
+      }
+      sessionStates.removeValue(forKey: id)
       if currentlyInstalledSessionID == id {
         currentlyInstalledSessionID = nil
         for sub in container?.subviews ?? [] { sub.removeFromSuperview() }
@@ -264,7 +726,7 @@ final class DFQuickTerminal {
   // MARK: - Shell startup
 
   private func startShell(
-    in tv: ClaudeTerminalView, for session: Session, workingDirectory: String?
+    in tv: ClaudeTerminalView, paneID: UUID, workingDirectory: String?
   ) {
     let parentEnv = ProcessInfo.processInfo.environment
     let shell = SessionManager.resolveShellPath(parentEnv: parentEnv)
@@ -298,21 +760,19 @@ final class DFQuickTerminal {
       environment: env,
       execName: nil)
 
-    let sessionID = session.id
-
     // Watch the raw PTY stream for the invisible ready marker. dataReceived
     // (and thus onPtyData) fires on the main thread, so timer scheduling and
     // mutation of the load's scan state here are safe. Once the marker is
     // seen the shell is genuinely ready; a short quiescence after lets the
     // fresh prompt paint before we reveal.
     tv.onPtyData = { [weak self] slice in
-      guard let self = self, let load = self.loads[sessionID] else { return }
+      guard let self = self, let load = self.loads[paneID] else { return }
       if !load.sawMarker {
         self.appendToScanBuffer(slice, of: load)
         guard load.scanBuffer.contains(Self.readyToken) else { return }
         load.sawMarker = true
       }
-      self.scheduleSettle(for: sessionID)
+      self.scheduleSettle(for: paneID)
     }
 
     // Login shell lands in $HOME; cd into the session's worktree so the quick
@@ -327,10 +787,10 @@ final class DFQuickTerminal {
     tv.send(txt: "\(cdPrefix)clear; \(Self.readyMarkerCommand)\r")
 
     // Hard ceiling so the overlay never sticks if the marker never arrives.
-    loads[sessionID]?.maxTimer = Timer.scheduledTimer(
+    loads[paneID]?.maxTimer = Timer.scheduledTimer(
       withTimeInterval: Self.maxLoad, repeats: false
     ) { [weak self] _ in
-      self?.finishLoading(for: sessionID)
+      self?.finishLoading(for: paneID)
     }
   }
 
@@ -357,36 +817,41 @@ final class DFQuickTerminal {
 
   /// (Re)arm the quiescence timer: once the marker has been seen, when PTY
   /// output then stays quiet for `settleQuiet`, the shell is ready.
-  private func scheduleSettle(for sessionID: UUID) {
-    guard let load = loads[sessionID], load.sawMarker else { return }
+  private func scheduleSettle(for paneID: UUID) {
+    guard let load = loads[paneID], load.sawMarker else { return }
     load.settleTimer?.invalidate()
     load.settleTimer = Timer.scheduledTimer(
       withTimeInterval: Self.settleQuiet, repeats: false
     ) { [weak self] _ in
-      self?.finishLoading(for: sessionID)
+      self?.finishLoading(for: paneID)
     }
   }
 
   /// Shell is ready: stop watching, fade out the overlay, and hand focus to
-  /// the terminal if this session is the visible one.
-  private func finishLoading(for sessionID: UUID) {
-    guard let load = loads.removeValue(forKey: sessionID) else { return }
+  /// the terminal if this pane is the one that should have it.
+  private func finishLoading(for paneID: UUID) {
+    guard let load = loads.removeValue(forKey: paneID) else { return }
     load.settleTimer?.invalidate()
     load.maxTimer?.invalidate()
-    terminals[sessionID]?.onPtyData = nil
+    load.terminalView.onPtyData = nil
     load.overlay.fadeOut { [weak self] in
-      guard let self = self,
-        self.currentlyInstalledSessionID == sessionID,
-        let win = self.window, win.isKeyWindow,
-        let tv = self.terminals[sessionID]
-      else { return }
-      win.makeFirstResponder(tv)
+      self?.focusIfStillWanted(paneID: paneID, terminalView: load.terminalView)
     }
   }
 
+  private func focusIfStillWanted(paneID: UUID, terminalView: ClaudeTerminalView) {
+    guard let win = window, win.isKeyWindow,
+      let sessionID = currentlyInstalledSessionID,
+      let state = sessionStates[sessionID],
+      let tab = state.activeTab,
+      tab.lastFocusedPaneID == paneID
+    else { return }
+    win.makeFirstResponder(terminalView)
+  }
+
   /// Abandon loading without revealing (shell exited, session deleted).
-  private func cancelLoading(for sessionID: UUID) {
-    guard let load = loads.removeValue(forKey: sessionID) else { return }
+  private func cancelLoading(for paneID: UUID) {
+    guard let load = loads.removeValue(forKey: paneID) else { return }
     load.settleTimer?.invalidate()
     load.maxTimer?.invalidate()
     load.overlay.removeFromSuperview()

--- a/Sources/DraftFrameKit/DFSessionBar.swift
+++ b/Sources/DraftFrameKit/DFSessionBar.swift
@@ -363,6 +363,23 @@ final class SessionCard: NSView {
     let avatar = GenerativeAvatar(seed: session.avatarSeed)
     avatar.translatesAutoresizingMaskIntoConstraints = false
 
+    // Positional Cmd+N badge in the card's corner. Only the first nine
+    // sessions have a shortcut; renumbers automatically since cards are
+    // rebuilt whenever the session list changes.
+    let numberBadge: NSTextField? = {
+      guard index < 9 else { return nil }
+      let badge = NSTextField(labelWithString: "\(index + 1)")
+      badge.font = Theme.mono(9, weight: .medium)
+      badge.textColor = isActive ? Theme.accent : Theme.text3
+      badge.alignment = .center
+      badge.wantsLayer = true
+      badge.layer?.backgroundColor = Theme.surface3.cgColor
+      badge.layer?.cornerRadius = 3
+      badge.toolTip = "Switch to session (\u{2318}\(index + 1))"
+      badge.translatesAutoresizingMaskIntoConstraints = false
+      return badge
+    }()
+
     // Name
     let nameLabel = NSTextField(labelWithString: session.displayName)
     nameLabel.font = Theme.mono(12, weight: .medium)
@@ -437,6 +454,7 @@ final class SessionCard: NSView {
       addSubview(v)
     }
     if let cl = contextLabel { addSubview(cl) }
+    if let badge = numberBadge { addSubview(badge) }
 
     // PR status pill (only if gh reports a PR for this worktree).
     let prStatus = PRMonitor.shared.status(for: session.id)
@@ -487,6 +505,14 @@ final class SessionCard: NSView {
       constraints.append(contentsOf: [
         pill.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
         pill.centerYAnchor.constraint(equalTo: dot.centerYAnchor),
+      ])
+    }
+    if let badge = numberBadge {
+      constraints.append(contentsOf: [
+        badge.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
+        badge.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+        badge.widthAnchor.constraint(greaterThanOrEqualToConstant: 13),
+        badge.heightAnchor.constraint(equalToConstant: 13),
       ])
     }
     NSLayoutConstraint.activate(constraints)

--- a/Sources/DraftFrameKit/DFTerminalPane.swift
+++ b/Sources/DraftFrameKit/DFTerminalPane.swift
@@ -299,8 +299,21 @@ final class DFTerminalPane: NSView {
         .foregroundColor: nameColor,
         .paragraphStyle: para,
       ]
-      nameBtn.attributedTitle = NSAttributedString(
-        string: " \(session.displayName) ", attributes: attrs)
+      // Positional Cmd+N number ahead of the name, dimmer than the name so
+      // it reads as chrome. Only the first nine sessions have a shortcut.
+      let title = NSMutableAttributedString()
+      if i < 9 {
+        title.append(
+          NSAttributedString(
+            string: " \(i + 1)",
+            attributes: [
+              .font: Theme.mono(9, weight: .medium),
+              .foregroundColor: isActive ? Theme.accent : Theme.text3,
+              .paragraphStyle: para,
+            ]))
+      }
+      title.append(NSAttributedString(string: " \(session.displayName) ", attributes: attrs))
+      nameBtn.attributedTitle = title
       nameBtn.cell?.lineBreakMode = .byTruncatingTail
       nameBtn.cell?.truncatesLastVisibleLine = true
       // Let the name truncate rather than widen the tab past its cap.

--- a/Sources/DraftFrameKit/DFWindowController.swift
+++ b/Sources/DraftFrameKit/DFWindowController.swift
@@ -227,6 +227,30 @@ final class DFWindowController: NSWindowController {
       DFQuickTerminal.shared.toggle()
     }
 
+    shortcuts.onQuickTerminalNewTab = {
+      DFQuickTerminal.shared.addTab()
+    }
+
+    shortcuts.onQuickTerminalSplitVertical = {
+      DFQuickTerminal.shared.splitFocusedPane(.vertical)
+    }
+
+    shortcuts.onQuickTerminalSplitHorizontal = {
+      DFQuickTerminal.shared.splitFocusedPane(.horizontal)
+    }
+
+    shortcuts.onQuickTerminalCloseFocusedPane = {
+      DFQuickTerminal.shared.closeFocusedPane()
+    }
+
+    shortcuts.onQuickTerminalCloseTab = {
+      DFQuickTerminal.shared.closeActiveTab()
+    }
+
+    shortcuts.onQuickTerminalJumpTo = { index in
+      DFQuickTerminal.shared.jumpTo(index: index)
+    }
+
     shortcuts.install()
   }
 

--- a/Sources/DraftFrameKit/QuickTerminalTree.swift
+++ b/Sources/DraftFrameKit/QuickTerminalTree.swift
@@ -1,0 +1,140 @@
+import AppKit
+import SwiftTerm
+
+/// Orientation of a quick-terminal split: `vertical` divides the space with a
+/// vertical divider (panes side-by-side), `horizontal` divides it with a
+/// horizontal divider (panes stacked).
+enum QTSplitDirection {
+  case horizontal
+  case vertical
+}
+
+/// One leaf terminal within a quick-terminal tab's split tree.
+final class QTPane {
+  let id = UUID()
+  let terminalView: ClaudeTerminalView
+
+  init(terminalView: ClaudeTerminalView) {
+    self.terminalView = terminalView
+  }
+}
+
+/// A node in a quick-terminal tab's split tree: either a single terminal, or
+/// a split dividing space between two (or more, once further split) child
+/// nodes. Splitting always inserts exactly two children; further splitting
+/// one of those children nests another two-child split beneath it, so the
+/// tree stays an arbitrary binary split tree (tmux/iTerm-style).
+indirect enum QTNode {
+  case leaf(QTPane)
+  case split(QTSplitDirection, [QTNode])
+
+  /// All panes in this subtree, in depth-first left-to-right order — used
+  /// both for numbering (Cmd+Shift+1-9) and for locating a pane's terminal
+  /// view.
+  func allPanes() -> [QTPane] {
+    switch self {
+    case .leaf(let pane):
+      return [pane]
+    case .split(_, let children):
+      return children.flatMap { $0.allPanes() }
+    }
+  }
+
+  /// Returns a new tree with the leaf matching `paneID` replaced by a split
+  /// containing that leaf followed by `newPane`. Returns `self` unchanged if
+  /// `paneID` isn't found.
+  func replacing(paneID: UUID, withSplit direction: QTSplitDirection, newPane: QTPane) -> QTNode {
+    switch self {
+    case .leaf(let pane):
+      if pane.id == paneID {
+        return .split(direction, [.leaf(pane), .leaf(newPane)])
+      }
+      return self
+    case .split(let dir, let children):
+      return .split(
+        dir,
+        children.map { $0.replacing(paneID: paneID, withSplit: direction, newPane: newPane) })
+    }
+  }
+
+  /// Returns a new tree with the leaf matching `paneID` removed, collapsing
+  /// any split left with a single child down to that child. Returns `nil` if
+  /// removing `paneID` empties this subtree entirely (i.e. this node *is*
+  /// that leaf).
+  func removing(paneID: UUID) -> QTNode? {
+    switch self {
+    case .leaf(let pane):
+      return pane.id == paneID ? nil : self
+    case .split(let dir, let children):
+      let remaining = children.compactMap { $0.removing(paneID: paneID) }
+      if remaining.count == 1 {
+        return remaining[0]
+      }
+      if remaining.isEmpty {
+        return nil
+      }
+      return .split(dir, remaining)
+    }
+  }
+}
+
+/// One tab within a session's quick terminal, holding its own split tree.
+/// Tabs have no stored name — they're displayed by position (1, 2, …), so
+/// numbering stays contiguous as tabs are closed and matches Option+1-9.
+final class QTTab {
+  let id = UUID()
+  var root: QTNode
+  var lastFocusedPaneID: UUID
+
+  init(pane: QTPane) {
+    self.root = .leaf(pane)
+    self.lastFocusedPaneID = pane.id
+  }
+
+  func allPanes() -> [QTPane] {
+    root.allPanes()
+  }
+
+  /// The pane last known to be focused, falling back to the tab's first pane
+  /// if that pane no longer exists (e.g. it was just closed).
+  func focusedPane() -> QTPane? {
+    let panes = allPanes()
+    return panes.first(where: { $0.id == lastFocusedPaneID }) ?? panes.first
+  }
+
+  /// Split the pane matching `paneID` in `direction`, inserting `newPane`
+  /// alongside it.
+  func split(paneID: UUID, direction: QTSplitDirection, newPane: QTPane) {
+    root = root.replacing(paneID: paneID, withSplit: direction, newPane: newPane)
+    lastFocusedPaneID = newPane.id
+  }
+
+  /// Remove the pane matching `paneID`. Returns `true` if the tab is now
+  /// empty (its last pane was removed).
+  func remove(paneID: UUID) -> Bool {
+    guard let newRoot = root.removing(paneID: paneID) else {
+      return true
+    }
+    root = newRoot
+    if lastFocusedPaneID == paneID {
+      lastFocusedPaneID = root.allPanes().first?.id ?? paneID
+    }
+    return false
+  }
+}
+
+/// A session's full quick-terminal state: its tabs, each with its own split
+/// tree, and which tab is currently active.
+final class QTSessionState {
+  var tabs: [QTTab] = []
+  var activeTabIndex: Int = 0
+
+  var activeTab: QTTab? {
+    tabs.indices.contains(activeTabIndex) ? tabs[activeTabIndex] : nil
+  }
+
+  /// The tab index containing the pane matching `paneID`, if any.
+  func tabIndex(ofPane paneID: UUID) -> Int? {
+    tabs.firstIndex { tab in tab.allPanes().contains { $0.id == paneID } }
+  }
+}

--- a/Sources/DraftFrameKit/Shortcuts.swift
+++ b/Sources/DraftFrameKit/Shortcuts.swift
@@ -13,6 +13,12 @@ final class ShortcutManager {
   var onToggleSidebar: (() -> Void)?
   var onToggleEditor: (() -> Void)?
   var onToggleQuickTerminal: (() -> Void)?
+  var onQuickTerminalNewTab: (() -> Void)?
+  var onQuickTerminalSplitVertical: (() -> Void)?
+  var onQuickTerminalSplitHorizontal: (() -> Void)?
+  var onQuickTerminalCloseFocusedPane: (() -> Void)?
+  var onQuickTerminalCloseTab: (() -> Void)?
+  var onQuickTerminalJumpTo: ((Int) -> Void)?
 
   private var keyDownMonitor: Any?
   private var keyUpMonitor: Any?
@@ -96,6 +102,52 @@ final class ShortcutManager {
         VoiceManager.shared.startListening()
       }
       return true
+    }
+
+    // Quick-terminal tab/split shortcuts, scoped to only fire while the
+    // popup terminal itself is the key window.
+    if DFQuickTerminal.shared.isFocused {
+      // Option+T: new tab
+      if flags == .option, event.keyCode == 17 {  // 't'
+        onQuickTerminalNewTab?()
+        return true
+      }
+
+      // Option+Shift+D: split horizontally (stacked)
+      if flags == [.option, .shift], event.keyCode == 2 {  // 'd'
+        onQuickTerminalSplitHorizontal?()
+        return true
+      }
+
+      // Option+D: split vertically (side-by-side)
+      if flags == .option, event.keyCode == 2 {  // 'd'
+        onQuickTerminalSplitVertical?()
+        return true
+      }
+
+      // Option+Shift+W: close the active tab (and every pane in it)
+      if flags == [.option, .shift], event.keyCode == 13 {  // 'w'
+        onQuickTerminalCloseTab?()
+        return true
+      }
+
+      // Option+W: close the focused pane
+      if flags == .option, event.keyCode == 13 {  // 'w'
+        onQuickTerminalCloseFocusedPane?()
+        return true
+      }
+
+      // Option+1 through Option+9: jump to terminal N
+      if flags == .option {
+        let digitKeyCodes: [UInt16: Int] = [
+          18: 1, 19: 2, 20: 3, 21: 4, 23: 5,
+          22: 6, 26: 7, 28: 8, 25: 9,
+        ]
+        if let terminalNum = digitKeyCodes[event.keyCode] {
+          onQuickTerminalJumpTo?(terminalNum - 1)
+          return true
+        }
+      }
     }
 
     // Cmd+1 through Cmd+9: switch to session N


### PR DESCRIPTION
## Summary

The floating quick terminal (Cmd+\`) now supports multiple terminals per session: tabs, recursive tmux-style splits, and tabs that each hold their own split layout. Everything stays session-scoped exactly like before — switching sessions swaps in that session's own tabs/splits with shells and scrollback intact.

### Shortcuts (active while the quick terminal is focused)

| Shortcut | Action |
|---|---|
| Option+T | New tab |
| Option+D | Split focused pane side-by-side |
| Option+Shift+D | Split focused pane stacked |
| Option+W | Close focused pane |
| Option+Shift+W | Close active tab |
| Option+1-9 | Jump to tab N |

Cmd+1-9 session switching is unchanged.

### Details

- New `QuickTerminalTree.swift` models the per-session state: tabs, each holding a recursive binary split tree of panes.
- Splits always divide 50/50; the focused pane gets a light accent outline so you can see where keystrokes go, and clicking any pane moves focus (with the border following).
- Tabs display their position (1, 2, 3…) and renumber as tabs close, so the label always matches Option+#.
- Main-window session tabs now show their Cmd+# number, and session cards carry a small corner badge with the same number — both position-derived, so they update on reorder/close.
- Closing a pane/tab kills the shell with SIGHUP rather than relying on SwiftTerm's `terminate()`: SIGTERM is ignored by interactive shells, and `terminate()` cancels its exit monitor without firing `processTerminated`, so a callback-based close never completes. Programmatic closes now do the model/UI removal directly; typed `exit` still flows through the process-exit callback.
- Closing a session also kills its quick-terminal shells instead of leaking them.

## Testing

- `swift-format lint --strict` clean, `swift build` clean, all 108 tests pass.
- Manually exercised: tab create/close/renumber, splits in both directions, focus-follows-click with border highlight, Option+# tab jumping, per-session isolation when switching sessions with the quick terminal open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)