### PR TITLE
Support Tab to move between fields in the New Worktree dialog

### DIFF
--- a/Sources/DraftFrameKit/NewWorktreeDialog.swift
+++ b/Sources/DraftFrameKit/NewWorktreeDialog.swift
@@ -157,6 +157,12 @@ enum NewWorktreeDialog {
       ticketField.placeholderString = "Ticket link (optional)"
       branchField.placeholderString = "existing-branch-name"
 
+      // Explicit key-view loop so Tab/Shift+Tab cycle between the fields;
+      // hidden fields (the mode not shown) are skipped automatically.
+      nameField.nextKeyView = ticketField
+      ticketField.nextKeyView = branchField
+      branchField.nextKeyView = nameField
+
       nameRow = fieldRow(label: "Name", field: nameField)
       ticketRow = fieldRow(label: "Ticket", field: ticketField)
       branchRow = fieldRow(label: "Branch", field: branchField)


### PR DESCRIPTION
Fixes #7

The shared worktree-creation sheet (`NewWorktreeDialog`) set `initialFirstResponder` but never wired the fields' `nextKeyView` chain, and an `NSWindow` doesn't recalculate its key-view loop automatically — so Tab had nowhere to go.

This wires a circular chain name → ticket → branch → name. AppKit's key-view traversal skips hidden views, so in New Branch mode Tab/Shift+Tab cycle name ↔ ticket, and in Existing Branch mode (only the branch field visible) the loop degenerates correctly. Covers all three entry points since they share this sheet.