### PR TITLE
Pull the base branch automatically when creating a worktree

### DIFF
--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -19,6 +19,11 @@ final class DFSidebar: NSView {
   /// only.
   private var pendingRemovals: Set<String> = []
 
+  /// Project paths with a `git pull` currently running. The project header's
+  /// pull button is replaced by a spinner while its path is in here, and
+  /// duplicate pulls for the same project are ignored. Main-thread only.
+  private var pullsInFlight: Set<String> = []
+
   /// Composed SF Symbol: leaf with a small "+" badge in the bottom-right.
   private static let leafPlusBadge: NSImage = {
     let size = NSSize(width: 16, height: 16)
@@ -56,6 +61,7 @@ final class DFSidebar: NSView {
     let projectPaths: [String]
     let activeDir: String?
     let pendingRemovals: Set<String>
+    let pullsInFlight: Set<String>
     let worktreesPerProject: [String: [WorktreeKey]]
   }
   private struct WorktreeKey: Equatable {
@@ -364,6 +370,7 @@ final class DFSidebar: NSView {
       projectPaths: projects.map { $0.path },
       activeDir: activeDir,
       pendingRemovals: pendingRemovals,
+      pullsInFlight: pullsInFlight,
       worktreesPerProject: worktreesPerProject.mapValues { wts in
         wts.map { WorktreeKey(path: $0.path, branch: $0.branch, isBare: $0.isBare) }
       }
@@ -449,6 +456,39 @@ final class DFSidebar: NSView {
         addBtn.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
         addBtn.widthAnchor.constraint(equalToConstant: 16),
         addBtn.heightAnchor.constraint(equalToConstant: 16),
+      ])
+
+      // Pull button (or a spinner while a pull runs) so the base branch new
+      // worktrees start from can be brought up to date with its remote
+      // without leaving the app.
+      let pullView: NSView
+      if pullsInFlight.contains(project.path) {
+        let spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.isIndeterminate = true
+        spinner.isDisplayedWhenStopped = false
+        spinner.startAnimation(nil)
+        pullView = spinner
+      } else {
+        let pullBtn = NSButton(title: "", target: self, action: #selector(pullProject(_:)))
+        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
+        pullBtn.image = NSImage(systemSymbolName: "arrow.down", accessibilityDescription: "Pull")?
+          .withSymbolConfiguration(config)
+        pullBtn.isBordered = false
+        pullBtn.imageScaling = .scaleProportionallyDown
+        pullBtn.contentTintColor = Theme.text3
+        pullBtn.toolTip = "Pull base branch in \(project.name)"
+        pullBtn.tag = idx
+        pullView = pullBtn
+      }
+      pullView.translatesAutoresizingMaskIntoConstraints = false
+      projectRow.addSubview(pullView)
+      NSLayoutConstraint.activate([
+        pullView.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
+        pullView.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
+        pullView.widthAnchor.constraint(equalToConstant: 16),
+        pullView.heightAnchor.constraint(equalToConstant: 16),
       ])
 
       let menu = NSMenu()
@@ -768,6 +808,37 @@ final class DFSidebar: NSView {
       message: "Create a worktree in \(project.name)."
     ) { result in
       self.handleWorktreeDialogResult(result, repoRoot: project.path)
+    }
+  }
+
+  @objc private func pullProject(_ sender: NSButton) {
+    let projects = ProjectManager.shared.projects
+    guard sender.tag >= 0, sender.tag < projects.count else { return }
+    let project = projects[sender.tag]
+    guard !pullsInFlight.contains(project.path) else { return }
+
+    pullsInFlight.insert(project.path)
+    refreshWorktrees()
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      let result = Result {
+        try WorktreeManager.shared.pull(repoRoot: project.path)
+      }
+      DispatchQueue.main.async {
+        self.pullsInFlight.remove(project.path)
+        self.refreshWorktrees()
+        if case .failure(let error) = result {
+          let alert = NSAlert()
+          alert.messageText = "Pull Failed"
+          alert.informativeText = error.localizedDescription
+          alert.alertStyle = .warning
+          if let win = self.window {
+            alert.beginSheetModal(for: win)
+          } else {
+            alert.runModal()
+          }
+        }
+      }
     }
   }
 

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -19,10 +19,10 @@ final class DFSidebar: NSView {
   /// only.
   private var pendingRemovals: Set<String> = []
 
-  /// Project paths with a `git pull` currently running. The project header's
-  /// pull button is replaced by a spinner while its path is in here, and
-  /// duplicate pulls for the same project are ignored. Main-thread only.
-  private var pullsInFlight: Set<String> = []
+  /// Project paths with a worktree setup (base-branch pull + worktree create)
+  /// currently running in the background. The project header shows a spinner
+  /// while its path is in here. Main-thread only.
+  private var worktreeSetupsInFlight: Set<String> = []
 
   /// Composed SF Symbol: leaf with a small "+" badge in the bottom-right.
   private static let leafPlusBadge: NSImage = {
@@ -61,7 +61,7 @@ final class DFSidebar: NSView {
     let projectPaths: [String]
     let activeDir: String?
     let pendingRemovals: Set<String>
-    let pullsInFlight: Set<String>
+    let worktreeSetupsInFlight: Set<String>
     let worktreesPerProject: [String: [WorktreeKey]]
   }
   private struct WorktreeKey: Equatable {
@@ -370,7 +370,7 @@ final class DFSidebar: NSView {
       projectPaths: projects.map { $0.path },
       activeDir: activeDir,
       pendingRemovals: pendingRemovals,
-      pullsInFlight: pullsInFlight,
+      worktreeSetupsInFlight: worktreeSetupsInFlight,
       worktreesPerProject: worktreesPerProject.mapValues { wts in
         wts.map { WorktreeKey(path: $0.path, branch: $0.branch, isBare: $0.isBare) }
       }
@@ -458,38 +458,26 @@ final class DFSidebar: NSView {
         addBtn.heightAnchor.constraint(equalToConstant: 16),
       ])
 
-      // Pull button (or a spinner while a pull runs) so the base branch new
-      // worktrees start from can be brought up to date with its remote
-      // without leaving the app.
-      let pullView: NSView
-      if pullsInFlight.contains(project.path) {
+      // While a worktree setup (base-branch pull + create) runs for this
+      // project, show a spinner next to the add button.
+      var trailingControl: NSView = addBtn
+      if worktreeSetupsInFlight.contains(project.path) {
         let spinner = NSProgressIndicator()
         spinner.style = .spinning
         spinner.controlSize = .small
         spinner.isIndeterminate = true
         spinner.isDisplayedWhenStopped = false
         spinner.startAnimation(nil)
-        pullView = spinner
-      } else {
-        let pullBtn = NSButton(title: "", target: self, action: #selector(pullProject(_:)))
-        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
-        pullBtn.image = NSImage(systemSymbolName: "arrow.down", accessibilityDescription: "Pull")?
-          .withSymbolConfiguration(config)
-        pullBtn.isBordered = false
-        pullBtn.imageScaling = .scaleProportionallyDown
-        pullBtn.contentTintColor = Theme.text3
-        pullBtn.toolTip = "Pull base branch in \(project.name)"
-        pullBtn.tag = idx
-        pullView = pullBtn
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        projectRow.addSubview(spinner)
+        NSLayoutConstraint.activate([
+          spinner.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
+          spinner.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
+          spinner.widthAnchor.constraint(equalToConstant: 16),
+          spinner.heightAnchor.constraint(equalToConstant: 16),
+        ])
+        trailingControl = spinner
       }
-      pullView.translatesAutoresizingMaskIntoConstraints = false
-      projectRow.addSubview(pullView)
-      NSLayoutConstraint.activate([
-        pullView.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
-        pullView.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
-        pullView.widthAnchor.constraint(equalToConstant: 16),
-        pullView.heightAnchor.constraint(equalToConstant: 16),
-      ])
 
       // The row label has no trailing constraint of its own; in a narrow
       // sidebar a long project name would run underneath the buttons. Pin it
@@ -497,8 +485,9 @@ final class DFSidebar: NSView {
       if let lbl = projectRow.subviews.compactMap({ $0 as? NSTextField }).first {
         lbl.lineBreakMode = .byTruncatingTail
         lbl.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        lbl.trailingAnchor.constraint(lessThanOrEqualTo: pullView.leadingAnchor, constant: -6)
-          .isActive = true
+        lbl.trailingAnchor.constraint(
+          lessThanOrEqualTo: trailingControl.leadingAnchor, constant: -6
+        ).isActive = true
       }
 
       let menu = NSMenu()
@@ -821,37 +810,6 @@ final class DFSidebar: NSView {
     }
   }
 
-  @objc private func pullProject(_ sender: NSButton) {
-    let projects = ProjectManager.shared.projects
-    guard sender.tag >= 0, sender.tag < projects.count else { return }
-    let project = projects[sender.tag]
-    guard !pullsInFlight.contains(project.path) else { return }
-
-    pullsInFlight.insert(project.path)
-    refreshWorktrees()
-
-    DispatchQueue.global(qos: .userInitiated).async {
-      let result = Result {
-        try WorktreeManager.shared.pull(repoRoot: project.path)
-      }
-      DispatchQueue.main.async {
-        self.pullsInFlight.remove(project.path)
-        self.refreshWorktrees()
-        if case .failure(let error) = result {
-          let alert = NSAlert()
-          alert.messageText = "Pull Failed"
-          alert.informativeText = error.localizedDescription
-          alert.alertStyle = .warning
-          if let win = self.window {
-            alert.beginSheetModal(for: win)
-          } else {
-            alert.runModal()
-          }
-        }
-      }
-    }
-  }
-
   @objc private func addWorktreeFromBranch(_ sender: NSMenuItem) {
     guard let projectPath = sender.representedObject as? String else { return }
     guard let win = window else { return }
@@ -874,6 +832,13 @@ final class DFSidebar: NSView {
   ) {
     switch result {
     case .newBranch(let name, let ticket):
+      // Branching off the primary worktree's checked-out branch (no explicit
+      // base): bring that branch up to date with its remote first so new
+      // worktrees don't silently start from a stale base.
+      if baseBranch == nil {
+        createWorktreeAfterPull(repoRoot: repoRoot, name: name, ticket: ticket)
+        return
+      }
       guard
         let path = NewWorktreeDialog.createWorktreeReportingErrors(
           repoRoot: repoRoot, name: name, baseBranch: baseBranch)
@@ -889,6 +854,43 @@ final class DFSidebar: NSView {
       SessionManager.shared.createSession(name: branch, worktreePath: path)
     }
     refreshWorktrees()
+  }
+
+  /// Pull the base branch, then create the worktree — both off the main
+  /// thread, with a spinner on the project row meanwhile. The pull is
+  /// best-effort: on failure (offline, diverged local branch) the worktree is
+  /// still created from the local state and the error shows as a transient
+  /// toast at the bottom of the window.
+  private func createWorktreeAfterPull(repoRoot: String, name: String, ticket: String?) {
+    worktreeSetupsInFlight.insert(repoRoot)
+    refreshWorktrees()
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      let pullResult = Result { try WorktreeManager.shared.pull(repoRoot: repoRoot) }
+      let createResult = Result {
+        try WorktreeManager.shared.createWorktree(repoRoot: repoRoot, name: name)
+      }
+      DispatchQueue.main.async {
+        self.worktreeSetupsInFlight.remove(repoRoot)
+        self.refreshWorktrees()
+
+        if case .failure(let pullError) = pullResult, let win = self.window {
+          let suffix =
+            (try? createResult.get()) != nil
+            ? " The worktree was created from the local branch." : ""
+          DFToast.show("\(pullError.localizedDescription)\(suffix)", in: win)
+        }
+
+        switch createResult {
+        case .success(let path):
+          SessionManager.shared.createSession(
+            name: name, worktreePath: path,
+            initialPrompt: ticket.map(TicketLink.kickoffPrompt))
+        case .failure(let error):
+          NewWorktreeDialog.reportError(error)
+        }
+      }
+    }
   }
 
   @objc private func addWorktreeFromWorktree(_ sender: NSMenuItem) {

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -491,6 +491,16 @@ final class DFSidebar: NSView {
         pullView.heightAnchor.constraint(equalToConstant: 16),
       ])
 
+      // The row label has no trailing constraint of its own; in a narrow
+      // sidebar a long project name would run underneath the buttons. Pin it
+      // clear of them and truncate the name instead.
+      if let lbl = projectRow.subviews.compactMap({ $0 as? NSTextField }).first {
+        lbl.lineBreakMode = .byTruncatingTail
+        lbl.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        lbl.trailingAnchor.constraint(lessThanOrEqualTo: pullView.leadingAnchor, constant: -6)
+          .isActive = true
+      }
+
       let menu = NSMenu()
       let switchItem = NSMenuItem(
         title: "Switch to Project", action: #selector(switchToProject(_:)), keyEquivalent: "")

--- a/Sources/DraftFrameKit/DFToast.swift
+++ b/Sources/DraftFrameKit/DFToast.swift
@@ -1,0 +1,91 @@
+import AppKit
+
+/// Transient error banner shown at the bottom of a window, floating just
+/// above the status bar. Fades in, auto-dismisses after `duration` seconds,
+/// and can be dismissed early with a click. Showing a new toast replaces any
+/// toast currently on screen.
+enum DFToast {
+  private static weak var current: ToastView?
+
+  static func show(_ message: String, in window: NSWindow, duration: TimeInterval = 5) {
+    guard let content = window.contentView else { return }
+    current?.dismiss(animated: false)
+
+    let toast = ToastView(message: message)
+    current = toast
+    content.addSubview(toast)
+    NSLayoutConstraint.activate([
+      toast.centerXAnchor.constraint(equalTo: content.centerXAnchor),
+      toast.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -40),
+      toast.widthAnchor.constraint(lessThanOrEqualTo: content.widthAnchor, constant: -80),
+    ])
+
+    toast.alphaValue = 0
+    NSAnimationContext.runAnimationGroup { ctx in
+      ctx.duration = 0.2
+      toast.animator().alphaValue = 1
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak toast] in
+      toast?.dismiss(animated: true)
+    }
+  }
+
+  private final class ToastView: NSView {
+    init(message: String) {
+      super.init(frame: .zero)
+      translatesAutoresizingMaskIntoConstraints = false
+      wantsLayer = true
+      layer?.backgroundColor = Theme.surface2.cgColor
+      layer?.cornerRadius = 6
+      layer?.borderWidth = 1
+      layer?.borderColor = Theme.red.withAlphaComponent(0.4).cgColor
+
+      let icon = NSImageView()
+      icon.image = NSImage(
+        systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "Error")
+      icon.contentTintColor = Theme.red
+      icon.translatesAutoresizingMaskIntoConstraints = false
+
+      let label = NSTextField(wrappingLabelWithString: message)
+      label.font = Theme.mono(11)
+      label.textColor = Theme.text1
+      label.translatesAutoresizingMaskIntoConstraints = false
+
+      addSubview(icon)
+      addSubview(label)
+      NSLayoutConstraint.activate([
+        icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+        icon.centerYAnchor.constraint(equalTo: centerYAnchor),
+        icon.widthAnchor.constraint(equalToConstant: 14),
+        icon.heightAnchor.constraint(equalToConstant: 14),
+        label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 8),
+        label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+        label.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+        label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+      ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func mouseDown(with event: NSEvent) {
+      dismiss(animated: true)
+    }
+
+    func dismiss(animated: Bool) {
+      guard superview != nil else { return }
+      if !animated {
+        removeFromSuperview()
+        return
+      }
+      NSAnimationContext.runAnimationGroup(
+        { ctx in
+          ctx.duration = 0.25
+          animator().alphaValue = 0
+        },
+        completionHandler: { [weak self] in
+          self?.removeFromSuperview()
+        })
+    }
+  }
+}

--- a/Sources/DraftFrameKit/NewWorktreeDialog.swift
+++ b/Sources/DraftFrameKit/NewWorktreeDialog.swift
@@ -67,7 +67,9 @@ enum NewWorktreeDialog {
     }
   }
 
-  private static func reportError(_ error: Error) {
+  /// The standard "Worktree Error" alert, shared with callers that run the
+  /// create off the main thread themselves.
+  static func reportError(_ error: Error) {
     let errAlert = NSAlert()
     errAlert.messageText = "Worktree Error"
     errAlert.informativeText = error.localizedDescription

--- a/Sources/DraftFrameKit/WorktreeManager.swift
+++ b/Sources/DraftFrameKit/WorktreeManager.swift
@@ -333,6 +333,42 @@ final class WorktreeManager {
     }
   }
 
+  /// Pull the branch checked out in the repo's primary worktree — the branch
+  /// new worktrees are based on when none is specified. Fast-forward only, so
+  /// a diverged local branch fails with git's explanation instead of silently
+  /// creating a merge commit.
+  func pull(repoRoot root: String) throws {
+    // Scrub GIT_* env vars so a stray GIT_DIR/GIT_WORK_TREE inherited from
+    // the launching session doesn't redirect git to the wrong repo.
+    let env = ProcessInfo.processInfo.environment
+      .filter { !$0.key.hasPrefix("GIT_") }
+
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    proc.arguments = ["-C", root, "pull", "--ff-only"]
+    proc.environment = env
+    proc.standardOutput = FileHandle.nullDevice
+    let errPipe = Pipe()
+    proc.standardError = errPipe
+
+    do {
+      try proc.run()
+    } catch {
+      throw WorktreeError.pullFailed(error.localizedDescription)
+    }
+    // Read to EOF before waiting — stderr past the 64KB pipe buffer would
+    // otherwise deadlock git against waitUntilExit().
+    let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+    proc.waitUntilExit()
+
+    if proc.terminationStatus != 0 {
+      let errMsg = String(data: errData, encoding: .utf8)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      throw WorktreeError.pullFailed(
+        (errMsg?.isEmpty == false) ? errMsg! : "git pull exited with a non-zero status")
+    }
+  }
+
   /// Best-effort `git branch -D <name>`. Silently ignores failures (the
   /// branch may already be gone, or it may be checked out elsewhere).
   private func deleteBranch(name: String, repoRoot root: String, env: [String: String]) {
@@ -381,11 +417,13 @@ final class WorktreeManager {
   enum WorktreeError: Error, LocalizedError {
     case creationFailed(String)
     case removeFailed(String)
+    case pullFailed(String)
 
     var errorDescription: String? {
       switch self {
       case .creationFailed(let msg): return "Worktree creation failed: \(msg)"
       case .removeFailed(let msg): return "Worktree removal failed: \(msg)"
+      case .pullFailed(let msg): return "Pull failed: \(msg)"
       }
     }
   }


### PR DESCRIPTION
Closes #9.

New worktrees branch off the local default branch, so a stale local `main`/`master` silently produced stale worktrees. Now creating a worktree brings the base branch up to date first — without ever blocking creation.

## Changes

- **Pull on create**: the "New Worktree" flow (no explicit base) runs `git pull --ff-only` in the project root before `git worktree add`, both on a background queue. The project header row shows a spinner while the setup runs; the dialog closes immediately.
- **Best-effort pull**: if the pull fails (offline, diverged local branch, auth), the worktree is still created from the local state. The error surfaces as a transient toast at the bottom of the window (new `DFToast` component) that auto-dismisses after 5 seconds or on click, noting the worktree was created from the local branch.
- **Scoped**: "New Worktree from Branch" / from-worktree flows (explicit base) and existing-branch checkouts are unchanged — pulling the root's checked-out branch wouldn't freshen those bases.
- **`WorktreeManager.pull(repoRoot:)`**: env-scrubbed `git pull --ff-only` following the codebase's process conventions, with a new `WorktreeError.pullFailed` case.
- **Sidebar fix**: project-row labels now truncate with an ellipsis instead of running underneath the trailing buttons when the sidebar is narrow.

## Testing

- `swift build`, `swift test` (108 tests) and `swift-format lint --strict` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)