### PR TITLE
Add Pull main/master to the project context menu

### DIFF
--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -19,6 +19,11 @@ final class DFSidebar: NSView {
   /// only.
   private var pendingRemovals: Set<String> = []
 
+  /// Project paths whose default branch is currently being pulled. The
+  /// project row shows a spinner and its "Pull <branch>" menu item is
+  /// disabled while the background `git pull` runs. Main-thread only.
+  private var pullsInFlight: Set<String> = []
+
   /// Composed SF Symbol: leaf with a small "+" badge in the bottom-right.
   private static let leafPlusBadge: NSImage = {
     let size = NSSize(width: 16, height: 16)
@@ -56,6 +61,7 @@ final class DFSidebar: NSView {
     let projectPaths: [String]
     let activeDir: String?
     let pendingRemovals: Set<String>
+    let pullsInFlight: Set<String>
     let worktreesPerProject: [String: [WorktreeKey]]
   }
   private struct WorktreeKey: Equatable {
@@ -364,6 +370,7 @@ final class DFSidebar: NSView {
       projectPaths: projects.map { $0.path },
       activeDir: activeDir,
       pendingRemovals: pendingRemovals,
+      pullsInFlight: pullsInFlight,
       worktreesPerProject: worktreesPerProject.mapValues { wts in
         wts.map { WorktreeKey(path: $0.path, branch: $0.branch, isBare: $0.isBare) }
       }
@@ -451,6 +458,26 @@ final class DFSidebar: NSView {
         addBtn.heightAnchor.constraint(equalToConstant: 16),
       ])
 
+      // In-progress indicator for a background default-branch pull. The row
+      // rebuilds when `pullsInFlight` changes (it's part of the snapshot),
+      // so the spinner appears/disappears with the pull.
+      let isPulling = pullsInFlight.contains(project.path)
+      if isPulling {
+        let spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.isIndeterminate = true
+        spinner.startAnimation(nil)
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        projectRow.addSubview(spinner)
+        NSLayoutConstraint.activate([
+          spinner.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
+          spinner.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
+          spinner.widthAnchor.constraint(equalToConstant: 12),
+          spinner.heightAnchor.constraint(equalToConstant: 12),
+        ])
+      }
+
       let menu = NSMenu()
       let switchItem = NSMenuItem(
         title: "Switch to Project", action: #selector(switchToProject(_:)), keyEquivalent: "")
@@ -470,6 +497,21 @@ final class DFSidebar: NSView {
       fromBranchItem.target = self
       fromBranchItem.representedObject = project.path
       menu.addItem(fromBranchItem)
+
+      // Pull the default branch from its remote — keeps new worktrees (which
+      // branch off the local default branch) from starting stale. Skipped
+      // when no default branch is resolvable (e.g. not a git repo).
+      if let defaultBranch = WorktreeManager.shared.defaultBranch(repoRoot: project.path) {
+        // A nil action leaves the item disabled while a pull is in flight.
+        let pullItem = NSMenuItem(
+          title: isPulling ? "Pulling \(defaultBranch)…" : "Pull \(defaultBranch)",
+          action: isPulling ? nil : #selector(pullDefaultBranch(_:)),
+          keyEquivalent: "")
+        pullItem.target = self
+        pullItem.representedObject = DefaultBranchPullRequest(
+          repoRoot: project.path, branch: defaultBranch)
+        menu.addItem(pullItem)
+      }
 
       menu.addItem(NSMenuItem.separator())
       let removeItem = NSMenuItem(
@@ -741,6 +783,34 @@ final class DFSidebar: NSView {
     guard let path = sender.representedObject as? String else { return }
     if let wc = window?.windowController as? DFWindowController {
       wc.openProject(at: path)
+    }
+  }
+
+  @objc private func pullDefaultBranch(_ sender: NSMenuItem) {
+    guard let req = sender.representedObject as? DefaultBranchPullRequest else { return }
+    guard !pullsInFlight.contains(req.repoRoot) else { return }
+    pullsInFlight.insert(req.repoRoot)
+    refreshWorktrees()
+
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      let error = WorktreeManager.shared.pullDefaultBranch(
+        repoRoot: req.repoRoot, branch: req.branch)
+      DispatchQueue.main.async {
+        guard let self = self else { return }
+        self.pullsInFlight.remove(req.repoRoot)
+        self.refreshWorktrees()
+        if let error = error {
+          let alert = NSAlert()
+          alert.messageText = "Pull \(req.branch) Failed"
+          alert.informativeText = error.trimmingCharacters(in: .whitespacesAndNewlines)
+          alert.alertStyle = .warning
+          if let win = self.window {
+            alert.beginSheetModal(for: win)
+          } else {
+            alert.runModal()
+          }
+        }
+      }
     }
   }
 
@@ -1570,4 +1640,11 @@ private struct WorktreeRemovalRequest {
 private struct WorktreeBranchRequest {
   let source: WorktreeManager.Worktree
   let repoRoot: String
+}
+
+/// Payload stored on a "Pull <branch>" menu item so the action handler knows
+/// the repo and the default branch it resolved to when the menu was built.
+private struct DefaultBranchPullRequest {
+  let repoRoot: String
+  let branch: String
 }

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -479,6 +479,22 @@ final class DFSidebar: NSView {
       }
 
       let menu = NSMenu()
+
+      // Pull the default branch from its remote — keeps new worktrees (which
+      // branch off the local default branch) from starting stale. Skipped
+      // when no default branch is resolvable (e.g. not a git repo).
+      if let defaultBranch = WorktreeManager.shared.defaultBranch(repoRoot: project.path) {
+        // A nil action leaves the item disabled while a pull is in flight.
+        let pullItem = NSMenuItem(
+          title: isPulling ? "Pulling \(defaultBranch)…" : "Pull \(defaultBranch)",
+          action: isPulling ? nil : #selector(pullDefaultBranch(_:)),
+          keyEquivalent: "")
+        pullItem.target = self
+        pullItem.representedObject = DefaultBranchPullRequest(
+          repoRoot: project.path, branch: defaultBranch)
+        menu.addItem(pullItem)
+      }
+
       let switchItem = NSMenuItem(
         title: "Switch to Project", action: #selector(switchToProject(_:)), keyEquivalent: "")
       switchItem.target = self
@@ -497,21 +513,6 @@ final class DFSidebar: NSView {
       fromBranchItem.target = self
       fromBranchItem.representedObject = project.path
       menu.addItem(fromBranchItem)
-
-      // Pull the default branch from its remote — keeps new worktrees (which
-      // branch off the local default branch) from starting stale. Skipped
-      // when no default branch is resolvable (e.g. not a git repo).
-      if let defaultBranch = WorktreeManager.shared.defaultBranch(repoRoot: project.path) {
-        // A nil action leaves the item disabled while a pull is in flight.
-        let pullItem = NSMenuItem(
-          title: isPulling ? "Pulling \(defaultBranch)…" : "Pull \(defaultBranch)",
-          action: isPulling ? nil : #selector(pullDefaultBranch(_:)),
-          keyEquivalent: "")
-        pullItem.target = self
-        pullItem.representedObject = DefaultBranchPullRequest(
-          repoRoot: project.path, branch: defaultBranch)
-        menu.addItem(pullItem)
-      }
 
       menu.addItem(NSMenuItem.separator())
       let removeItem = NSMenuItem(

--- a/Sources/DraftFrameKit/WorktreeManager.swift
+++ b/Sources/DraftFrameKit/WorktreeManager.swift
@@ -187,24 +187,102 @@ final class WorktreeManager {
     throw WorktreeError.creationFailed(localError)
   }
 
+  /// Environment for git subprocesses: GIT_* vars scrubbed (a stray
+  /// GIT_DIR/GIT_WORK_TREE inherited from the launching session would
+  /// redirect git to the wrong repo) and terminal prompting disabled so a
+  /// network command can never hang waiting for credentials.
+  private static func gitEnvironment() -> [String: String] {
+    var env = ProcessInfo.processInfo.environment
+      .filter { !$0.key.hasPrefix("GIT_") }
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    return env
+  }
+
   /// Run git with `args`; returns nil on success, stderr text on failure.
   private func runGit(_ args: [String], in dir: String) -> String? {
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
     proc.arguments = args
+    proc.environment = Self.gitEnvironment()
     proc.currentDirectoryURL = URL(fileURLWithPath: dir)
     let errPipe = Pipe()
     proc.standardError = errPipe
-    proc.standardOutput = Pipe()
+    proc.standardOutput = FileHandle.nullDevice
+    let errData: Data
     do {
       try proc.run()
+      // Read to EOF before waiting — stderr past the 64KB pipe buffer would
+      // otherwise deadlock git against waitUntilExit().
+      errData = errPipe.fileHandleForReading.readDataToEndOfFile()
       proc.waitUntilExit()
     } catch {
       return error.localizedDescription
     }
     guard proc.terminationStatus != 0 else { return nil }
-    let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
     return String(data: errData, encoding: .utf8) ?? "Unknown error"
+  }
+
+  /// Run git with `args`; returns trimmed stdout on success, nil on failure.
+  private func gitOutput(_ args: [String], in dir: String) -> String? {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    proc.arguments = args
+    proc.environment = Self.gitEnvironment()
+    proc.currentDirectoryURL = URL(fileURLWithPath: dir)
+    let outPipe = Pipe()
+    proc.standardOutput = outPipe
+    proc.standardError = FileHandle.nullDevice
+    let data: Data
+    do {
+      try proc.run()
+      data = outPipe.fileHandleForReading.readDataToEndOfFile()
+      proc.waitUntilExit()
+    } catch {
+      return nil
+    }
+    guard proc.terminationStatus == 0 else { return nil }
+    return String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  /// Detect a repo's default branch: the remote HEAD when the clone recorded
+  /// one (refs/remotes/origin/HEAD), else a local `main` or `master`.
+  func defaultBranch(repoRoot root: String) -> String? {
+    if let ref = gitOutput(
+      ["-C", root, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"], in: root),
+      let name = ref.split(separator: "/", maxSplits: 1).last.map(String.init),
+      !name.isEmpty
+    {
+      return name
+    }
+    for name in ["main", "master"]
+    where gitOutput(
+      ["-C", root, "rev-parse", "--verify", "--quiet", "refs/heads/\(name)"], in: root) != nil
+    {
+      return name
+    }
+    return nil
+  }
+
+  /// Fast-forward `branch` (the repo's default branch) from its remote.
+  /// Returns nil on success, or a user-facing error message on failure.
+  ///
+  /// When the branch is checked out somewhere — the main repo or a worktree —
+  /// the pull runs from that checkout so the working tree advances with the
+  /// ref, and git itself reports why a plain pull isn't safe there (dirty
+  /// checkout, diverged history). When it isn't checked out anywhere, the
+  /// ref is fast-forwarded directly via `git fetch <remote> <branch>:<branch>`,
+  /// which touches no working tree and refuses non-fast-forward updates.
+  func pullDefaultBranch(repoRoot root: String, branch: String) -> String? {
+    let remote =
+      gitOutput(["-C", root, "config", "--get", "branch.\(branch).remote"], in: root) ?? "origin"
+
+    if let checkout = listWorktrees(repoRoot: root)
+      .first(where: { !$0.isBare && $0.branch == branch })
+    {
+      return runGit(["-C", checkout.path, "pull", "--ff-only", remote, branch], in: checkout.path)
+    }
+    return runGit(["-C", root, "fetch", remote, "\(branch):\(branch)"], in: root)
   }
 
   private func detectDefaultBranch(in dir: String) -> String? {
@@ -227,12 +305,18 @@ final class WorktreeManager {
   /// List all worktrees by parsing `git worktree list --porcelain`.
   func listWorktrees() -> [Worktree] {
     guard let root = repoRoot else { return [] }
+    return listWorktrees(repoRoot: root)
+  }
+
+  /// List the worktrees of the repo rooted at `root`.
+  func listWorktrees(repoRoot root: String) -> [Worktree] {
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
     proc.arguments = ["-C", root, "worktree", "list", "--porcelain"]
+    proc.environment = Self.gitEnvironment()
     let pipe = Pipe()
     proc.standardOutput = pipe
-    proc.standardError = Pipe()
+    proc.standardError = FileHandle.nullDevice
 
     do {
       try proc.run()

--- a/Tests/DraftFrameTests/WorktreeManagerPullTests.swift
+++ b/Tests/DraftFrameTests/WorktreeManagerPullTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+/// Exercises default-branch detection and the fast-forward pull against real
+/// temp git repos: a "remote" repo and a clone of it acting as the project.
+final class WorktreeManagerPullTests: XCTestCase {
+
+  private var tempDir: URL!
+  private var remoteDir: URL { tempDir.appendingPathComponent("remote") }
+  private var localDir: URL { tempDir.appendingPathComponent("local") }
+
+  override func setUpWithError() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("draftframe-pull-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: remoteDir, withIntermediateDirectories: true)
+    git(["init", "-b", "main"], in: remoteDir)
+    commit("one", in: remoteDir)
+    git(["clone", remoteDir.path, localDir.path], in: tempDir)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  // MARK: - Helpers
+
+  @discardableResult
+  private func git(_ args: [String], in dir: URL) -> String {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    proc.arguments = ["-C", dir.path] + args
+    let pipe = Pipe()
+    proc.standardOutput = pipe
+    proc.standardError = FileHandle.nullDevice
+    try? proc.run()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    proc.waitUntilExit()
+    return String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+
+  private func commit(_ name: String, in dir: URL) {
+    try? "content-\(name)".write(
+      to: dir.appendingPathComponent("\(name).txt"), atomically: true, encoding: .utf8)
+    git(["add", "."], in: dir)
+    git(
+      ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", name],
+      in: dir)
+  }
+
+  private func head(_ ref: String, in dir: URL) -> String {
+    git(["rev-parse", ref], in: dir)
+  }
+
+  // MARK: - Default branch detection
+
+  func testDetectsDefaultBranchFromRemoteHead() {
+    XCTAssertEqual(WorktreeManager.shared.defaultBranch(repoRoot: localDir.path), "main")
+  }
+
+  func testDetectsLocalDefaultBranchWithoutRemote() {
+    XCTAssertEqual(WorktreeManager.shared.defaultBranch(repoRoot: remoteDir.path), "main")
+  }
+
+  func testDetectsMasterFallback() {
+    git(["branch", "-m", "main", "master"], in: remoteDir)
+    XCTAssertEqual(WorktreeManager.shared.defaultBranch(repoRoot: remoteDir.path), "master")
+  }
+
+  func testReturnsNilOutsideGitRepo() {
+    let plainDir = tempDir.appendingPathComponent("plain")
+    try? FileManager.default.createDirectory(at: plainDir, withIntermediateDirectories: true)
+    XCTAssertNil(WorktreeManager.shared.defaultBranch(repoRoot: plainDir.path))
+  }
+
+  // MARK: - Pull
+
+  func testPullFastForwardsCheckedOutDefaultBranch() {
+    commit("two", in: remoteDir)
+    let error = WorktreeManager.shared.pullDefaultBranch(repoRoot: localDir.path, branch: "main")
+    XCTAssertNil(error)
+    XCTAssertEqual(head("main", in: localDir), head("main", in: remoteDir))
+  }
+
+  func testPullFastForwardsUncheckedOutBranchViaFetch() {
+    // Move the local checkout off main; the pull must still advance main
+    // without touching the checked-out branch.
+    git(["checkout", "-b", "feature"], in: localDir)
+    commit("two", in: remoteDir)
+    let error = WorktreeManager.shared.pullDefaultBranch(repoRoot: localDir.path, branch: "main")
+    XCTAssertNil(error)
+    XCTAssertEqual(head("main", in: localDir), head("main", in: remoteDir))
+    XCTAssertEqual(git(["branch", "--show-current"], in: localDir), "feature")
+  }
+
+  func testPullUpdatesDefaultBranchCheckedOutInWorktree() {
+    // Check main out in a linked worktree and move the primary checkout off
+    // it; the pull should run in the worktree and advance its working tree.
+    let wtDir = tempDir.appendingPathComponent("wt-main")
+    git(["checkout", "-b", "feature"], in: localDir)
+    git(["worktree", "add", wtDir.path, "main"], in: localDir)
+    commit("two", in: remoteDir)
+    let error = WorktreeManager.shared.pullDefaultBranch(repoRoot: localDir.path, branch: "main")
+    XCTAssertNil(error)
+    XCTAssertEqual(head("main", in: localDir), head("main", in: remoteDir))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: wtDir.appendingPathComponent("two.txt").path))
+  }
+
+  func testPullReportsDivergedBranch() {
+    commit("remote-change", in: remoteDir)
+    commit("local-change", in: localDir)
+    let error = WorktreeManager.shared.pullDefaultBranch(repoRoot: localDir.path, branch: "main")
+    XCTAssertNotNil(error)
+    // The local branch must be left where it was — no merge, no reset.
+    XCTAssertNotEqual(head("main", in: localDir), head("main", in: remoteDir))
+  }
+
+  func testPullReportsUnreachableRemote() {
+    try? FileManager.default.removeItem(at: remoteDir)
+    let error = WorktreeManager.shared.pullDefaultBranch(repoRoot: localDir.path, branch: "main")
+    XCTAssertNotNil(error)
+  }
+}

--- a/Tests/DraftFrameTests/WorktreeManagerPullTests.swift
+++ b/Tests/DraftFrameTests/WorktreeManagerPullTests.swift
@@ -104,7 +104,8 @@ final class WorktreeManagerPullTests: XCTestCase {
     let error = WorktreeManager.shared.pullDefaultBranch(repoRoot: localDir.path, branch: "main")
     XCTAssertNil(error)
     XCTAssertEqual(head("main", in: localDir), head("main", in: remoteDir))
-    XCTAssertTrue(FileManager.default.fileExists(atPath: wtDir.appendingPathComponent("two.txt").path))
+    XCTAssertTrue(
+      FileManager.default.fileExists(atPath: wtDir.appendingPathComponent("two.txt").path))
   }
 
   func testPullReportsDivergedBranch() {


### PR DESCRIPTION
Closes #11.

Adds a "Pull main" / "Pull master" item (title matches the detected default branch) to the project row's right-click menu in the sidebar.

## How it works

- `WorktreeManager.defaultBranch(repoRoot:)` resolves the default branch from the remote HEAD (`refs/remotes/origin/HEAD`), falling back to a local `main` or `master`. Projects with no resolvable default branch don't get the menu item.
- `WorktreeManager.pullDefaultBranch(repoRoot:branch:)` fast-forwards the branch from its configured remote (defaulting to origin):
  - If the branch is checked out somewhere (the main repo or a worktree), it runs `git pull --ff-only` from that checkout so the working tree advances with the ref, and git itself reports why a plain pull isn't safe there (dirty checkout, diverged history) instead of guessing.
  - If it isn't checked out anywhere, the ref is fast-forwarded directly via `git fetch <remote> <branch>:<branch>`, which touches no working tree and refuses non-fast-forward updates.
- The pull runs on a background queue; the project row shows a small spinner and the menu item flips to a disabled "Pulling main…" while it's in flight (tracked in a `pullsInFlight` set folded into the sidebar's content snapshot, mirroring the existing `pendingRemovals` pattern). Everything else — creating worktrees, switching sessions — keeps working.
- Failures (no network, diverged local branch, dirty checkout) surface in an alert with git's stderr after the pull finishes.
- Git subprocesses run with `GIT_*` env vars scrubbed and `GIT_TERMINAL_PROMPT=0` so a credential prompt can never hang the app.

## Tests

New `WorktreeManagerPullTests` exercise detection and pull against real temp repos: remote-HEAD and local main/master detection, fast-forward with the branch checked out, not checked out, and checked out in a linked worktree, plus diverged-branch and unreachable-remote failure reporting. All 117 tests pass.