### PR TITLE
Add Rename Worktree to the worktree context menu

### DIFF
--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -596,6 +596,18 @@ final class DFSidebar: NSView {
           wtMenu.addItem(branchItem)
           if !isBase {
             wtMenu.addItem(NSMenuItem.separator())
+            // Rename only applies to draftframe-managed worktrees — the
+            // primary checkout is the project root itself and can't be moved
+            // under .claude/worktrees/.
+            if !isPrimary {
+              let renameItem = NSMenuItem(
+                title: "Rename Worktree", action: #selector(renameWorktreeFromMenu(_:)),
+                keyEquivalent: "")
+              renameItem.target = self
+              renameItem.representedObject = WorktreeRenameRequest(
+                worktree: wt, repoRoot: project.path)
+              wtMenu.addItem(renameItem)
+            }
             let rmItem = NSMenuItem(
               title: "Remove Worktree", action: #selector(removeWorktreeFromMenu(_:)),
               keyEquivalent: "")
@@ -720,6 +732,49 @@ final class DFSidebar: NSView {
           if case .failure(let error) = result {
             let errAlert = NSAlert()
             errAlert.messageText = "Remove Failed"
+            errAlert.informativeText = error.localizedDescription
+            errAlert.runModal()
+          }
+          self.refreshWorktrees()
+        }
+      }
+    }
+  }
+
+  @objc private func renameWorktreeFromMenu(_ sender: NSMenuItem) {
+    guard let req = sender.representedObject as? WorktreeRenameRequest else { return }
+    let wt = req.worktree
+    let projectRoot = req.repoRoot
+    let oldName = wt.branch.isEmpty ? (wt.path as NSString).lastPathComponent : wt.branch
+
+    let alert = NSAlert()
+    alert.messageText = "Rename Worktree"
+    alert.informativeText = "Renames the branch and moves the worktree directory to match."
+    alert.addButton(withTitle: "Rename")
+    alert.addButton(withTitle: "Cancel")
+    let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+    field.stringValue = oldName
+    alert.accessoryView = field
+    alert.window.initialFirstResponder = field
+
+    guard let win = window else { return }
+    alert.beginSheetModal(for: win) { response in
+      guard response == .alertFirstButtonReturn else { return }
+      let newName = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !newName.isEmpty, newName != oldName else { return }
+
+      DispatchQueue.global(qos: .userInitiated).async {
+        let result = Result {
+          try WorktreeManager.shared.renameWorktree(
+            repoRoot: projectRoot, worktree: wt, newName: newName)
+        }
+        DispatchQueue.main.async {
+          switch result {
+          case .success(let newPath):
+            SessionManager.shared.worktreeRenamed(from: wt.path, to: newPath, newName: newName)
+          case .failure(let error):
+            let errAlert = NSAlert()
+            errAlert.messageText = "Rename Failed"
             errAlert.informativeText = error.localizedDescription
             errAlert.runModal()
           }
@@ -1698,6 +1753,13 @@ final class ClickableRow: NSView {
 /// Payload stored on a "Remove Worktree" menu item so the action handler knows
 /// both the worktree to remove and which project's repo it belongs to.
 private struct WorktreeRemovalRequest {
+  let worktree: WorktreeManager.Worktree
+  let repoRoot: String
+}
+
+/// Payload stored on a "Rename Worktree" menu item so the action handler knows
+/// both the worktree to rename and which project's repo it belongs to.
+private struct WorktreeRenameRequest {
   let worktree: WorktreeManager.Worktree
   let repoRoot: String
 }

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -470,6 +470,18 @@ final class SessionManager {
     NotificationCenter.default.post(name: .activeSessionDidChange, object: nil)
   }
 
+  /// Update the session bound to a worktree after the worktree was renamed
+  /// on disk: adopt the new name and path, and re-point the transcript and
+  /// status watchers at the new directory.
+  func worktreeRenamed(from oldPath: String, to newPath: String, newName: String) {
+    guard let session = sessions.first(where: { $0.worktreePath == oldPath }) else { return }
+    session.name = newName
+    session.worktreePath = newPath
+    session.stopWatchers()
+    session.startWatchers(directory: newPath)
+    NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+  }
+
   /// Close session by ID.
   func closeSession(id: UUID) {
     if let idx = sessions.firstIndex(where: { $0.id == id }) {

--- a/Sources/DraftFrameKit/WorktreeManager.swift
+++ b/Sources/DraftFrameKit/WorktreeManager.swift
@@ -417,6 +417,52 @@ final class WorktreeManager {
     }
   }
 
+  /// Rename a managed worktree: renames its checked-out branch to `newName`
+  /// and moves its directory to `<repo>/.claude/worktrees/<newName>`.
+  /// Returns the worktree's new path.
+  ///
+  /// `repoRoot` must be the main repo for this worktree; this does not
+  /// consult `self.repoRoot`.
+  func renameWorktree(repoRoot root: String, worktree: Worktree, newName: String) throws -> String {
+    let name = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !name.isEmpty else {
+      throw WorktreeError.renameFailed("The new name is empty.")
+    }
+    guard !name.contains("/") else {
+      throw WorktreeError.renameFailed("The new name can't contain \"/\".")
+    }
+    let newPath = root + Self.worktreeSubpath + "/" + name
+    // Compare symlink-resolved paths: git reports realpaths (e.g. /private/var
+    // on macOS) while callers may hold the unresolved spelling.
+    let resolvedNew = URL(fileURLWithPath: newPath).resolvingSymlinksInPath().path
+    let resolvedOld = URL(fileURLWithPath: worktree.path).resolvingSymlinksInPath().path
+    guard resolvedNew != resolvedOld else { return worktree.path }
+    guard !FileManager.default.fileExists(atPath: newPath) else {
+      throw WorktreeError.renameFailed("\(newPath) already exists.")
+    }
+
+    // Rename the branch first — `git branch -m` validates the new name and
+    // fails cleanly if a branch by that name already exists, leaving the
+    // worktree untouched.
+    let oldBranch = worktree.branch
+    if !oldBranch.isEmpty, oldBranch != name {
+      if let err = runGit(["-C", root, "branch", "-m", oldBranch, name], in: root) {
+        throw WorktreeError.renameFailed(err)
+      }
+    }
+
+    if let err = runGit(["-C", root, "worktree", "move", worktree.path, newPath], in: root) {
+      // Best-effort roll back the branch rename so a failed move doesn't
+      // leave the branch and directory names out of sync.
+      if !oldBranch.isEmpty, oldBranch != name {
+        _ = runGit(["-C", root, "branch", "-m", name, oldBranch], in: root)
+      }
+      throw WorktreeError.renameFailed(err)
+    }
+
+    return newPath
+  }
+
   /// Pull the branch checked out in the repo's primary worktree — the branch
   /// new worktrees are based on when none is specified. Fast-forward only, so
   /// a diverged local branch fails with git's explanation instead of silently
@@ -501,12 +547,14 @@ final class WorktreeManager {
   enum WorktreeError: Error, LocalizedError {
     case creationFailed(String)
     case removeFailed(String)
+    case renameFailed(String)
     case pullFailed(String)
 
     var errorDescription: String? {
       switch self {
       case .creationFailed(let msg): return "Worktree creation failed: \(msg)"
       case .removeFailed(let msg): return "Worktree removal failed: \(msg)"
+      case .renameFailed(let msg): return "Worktree rename failed: \(msg)"
       case .pullFailed(let msg): return "Pull failed: \(msg)"
       }
     }

--- a/Tests/DraftFrameTests/WorktreeManagerRenameTests.swift
+++ b/Tests/DraftFrameTests/WorktreeManagerRenameTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+/// Exercises worktree renaming against a real temp git repo with a
+/// draftframe-managed worktree under `.claude/worktrees/`.
+final class WorktreeManagerRenameTests: XCTestCase {
+
+  private var tempDir: URL!
+  private var repoDir: URL { tempDir.appendingPathComponent("repo") }
+  private var worktreesDir: URL {
+    repoDir.appendingPathComponent(".claude/worktrees")
+  }
+
+  override func setUpWithError() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("draftframe-rename-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    git(["init", "-b", "main"], in: repoDir)
+    commit("one", in: repoDir)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  // MARK: - Helpers
+
+  @discardableResult
+  private func git(_ args: [String], in dir: URL) -> String {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    proc.arguments = ["-C", dir.path] + args
+    let pipe = Pipe()
+    proc.standardOutput = pipe
+    proc.standardError = FileHandle.nullDevice
+    try? proc.run()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    proc.waitUntilExit()
+    return String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+
+  private func commit(_ name: String, in dir: URL) {
+    try? "content-\(name)".write(
+      to: dir.appendingPathComponent("\(name).txt"), atomically: true, encoding: .utf8)
+    git(["add", "."], in: dir)
+    git(
+      ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", name],
+      in: dir)
+  }
+
+  private func makeWorktree(named name: String) -> WorktreeManager.Worktree {
+    let path = worktreesDir.appendingPathComponent(name).path
+    git(["worktree", "add", "-b", name, path, "main"], in: repoDir)
+    let listed = WorktreeManager.shared.listWorktrees(repoRoot: repoDir.path)
+      .first { $0.branch == name }
+    return listed
+      ?? WorktreeManager.Worktree(path: path, branch: name, head: "", isBare: false)
+  }
+
+  // MARK: - Rename
+
+  func testRenameMovesDirectoryAndRenamesBranch() throws {
+    let wt = makeWorktree(named: "old-name")
+    let newPath = try WorktreeManager.shared.renameWorktree(
+      repoRoot: repoDir.path, worktree: wt, newName: "new-name")
+
+    XCTAssertEqual(newPath, worktreesDir.appendingPathComponent("new-name").path)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: newPath))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: wt.path))
+    XCTAssertEqual(
+      git(["branch", "--show-current"], in: URL(fileURLWithPath: newPath)), "new-name")
+
+    let branches = git(["branch", "--list"], in: repoDir)
+    XCTAssertTrue(branches.contains("new-name"))
+    XCTAssertFalse(branches.contains("old-name"))
+
+    // Git lists realpaths (/private/var vs /var for macOS temp dirs), so
+    // compare symlink-resolved paths.
+    let resolvedNew = URL(fileURLWithPath: newPath).resolvingSymlinksInPath().path
+    let listed = WorktreeManager.shared.listWorktrees(repoRoot: repoDir.path)
+    XCTAssertTrue(
+      listed.contains {
+        URL(fileURLWithPath: $0.path).resolvingSymlinksInPath().path == resolvedNew
+          && $0.branch == "new-name"
+      })
+  }
+
+  func testRenamePreservesUncommittedChanges() throws {
+    let wt = makeWorktree(named: "dirty")
+    let scratch = URL(fileURLWithPath: wt.path).appendingPathComponent("scratch.txt")
+    try "uncommitted".write(to: scratch, atomically: true, encoding: .utf8)
+
+    let newPath = try WorktreeManager.shared.renameWorktree(
+      repoRoot: repoDir.path, worktree: wt, newName: "renamed-dirty")
+
+    let moved = URL(fileURLWithPath: newPath).appendingPathComponent("scratch.txt")
+    XCTAssertEqual(try String(contentsOf: moved, encoding: .utf8), "uncommitted")
+  }
+
+  func testRenameToSameNameIsANoop() throws {
+    let wt = makeWorktree(named: "same")
+    let newPath = try WorktreeManager.shared.renameWorktree(
+      repoRoot: repoDir.path, worktree: wt, newName: "same")
+    XCTAssertEqual(newPath, wt.path)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: wt.path))
+  }
+
+  func testRenameRejectsEmptyName() {
+    let wt = makeWorktree(named: "keep")
+    XCTAssertThrowsError(
+      try WorktreeManager.shared.renameWorktree(
+        repoRoot: repoDir.path, worktree: wt, newName: "  "))
+  }
+
+  func testRenameRejectsNameWithSlash() {
+    let wt = makeWorktree(named: "flat")
+    XCTAssertThrowsError(
+      try WorktreeManager.shared.renameWorktree(
+        repoRoot: repoDir.path, worktree: wt, newName: "a/b"))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: wt.path))
+  }
+
+  func testRenameRejectsExistingBranchAndLeavesWorktreeInPlace() {
+    makeWorktree(named: "taken")
+    let wt = makeWorktree(named: "source")
+    XCTAssertThrowsError(
+      try WorktreeManager.shared.renameWorktree(
+        repoRoot: repoDir.path, worktree: wt, newName: "taken"))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: wt.path))
+    XCTAssertEqual(git(["branch", "--show-current"], in: URL(fileURLWithPath: wt.path)), "source")
+  }
+
+  func testRenameRejectsOccupiedDestinationPath() throws {
+    let wt = makeWorktree(named: "blocked")
+    // Occupy the destination path with a plain directory; the rename must
+    // refuse before touching the branch or the worktree.
+    let destination = worktreesDir.appendingPathComponent("occupied")
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+
+    XCTAssertThrowsError(
+      try WorktreeManager.shared.renameWorktree(
+        repoRoot: repoDir.path, worktree: wt, newName: "occupied"))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: wt.path))
+    XCTAssertEqual(git(["branch", "--show-current"], in: URL(fileURLWithPath: wt.path)), "blocked")
+  }
+}


### PR DESCRIPTION
Closes #14

Right-clicking a worktree row now offers **Rename Worktree** (managed worktrees only, not the base entry or primary checkout). A sheet prefilled with the current name prompts for the new one; on confirm:

- `WorktreeManager.renameWorktree` renames the checked-out branch with `git branch -m` (fails cleanly if the name is taken), then moves the directory to `.claude/worktrees/<newName>` with `git worktree move`, rolling back the branch rename if the move fails. Validates the name and treats a same-name rename as a no-op, comparing symlink-resolved paths since git reports realpaths.
- Any open session on that worktree adopts the new name and path, and its transcript/status watchers restart against the new directory, so the sidebar session label follows the rename.
- The sidebar refreshes; failures surface in a standard error alert.

Tests: `WorktreeManagerRenameTests` covers the happy path, preserved uncommitted changes, same-name no-op, empty/slash names, taken branch name, and an occupied destination path, all against a real temp repo. Full suite and `swift-format lint --strict` pass.