### PR TITLE
Fix session menu actions lost to card rebuilds; harden worktree rename/remove paths

### DIFF
--- a/Sources/DraftFrameKit/DFSessionBar.swift
+++ b/Sources/DraftFrameKit/DFSessionBar.swift
@@ -102,7 +102,7 @@ final class DFSessionBar: NSView {
     }
 
     for (i, session) in sessions.enumerated() {
-      let card = SessionCard(session: session, isActive: i == activeIdx, index: i)
+      let card = SessionCard(session: session, isActive: i == activeIdx, index: i, bar: self)
       card.translatesAutoresizingMaskIntoConstraints = false
       card.widthAnchor.constraint(equalToConstant: 284).isActive = true
       cardStack.addArrangedSubview(card)
@@ -189,6 +189,116 @@ final class DFSessionBar: NSView {
     dropIndicator.isHidden = true
     lastDropIndex = nil
   }
+
+  // MARK: - Card context-menu actions
+
+  // Card menu items target the bar, not the card: cards are torn down and
+  // rebuilt on every `.sessionsDidChange` tick (~1.5s while an agent works),
+  // and NSMenuItem holds its target weakly — targeting the card meant any
+  // rebuild while the menu or a confirmation sheet was open silently dropped
+  // the action (issue #13). The bar lives as long as the window, and each
+  // item retains its Session via `representedObject`.
+
+  private func payload(from sender: NSMenuItem) -> SessionCardMenuPayload? {
+    sender.representedObject as? SessionCardMenuPayload
+  }
+
+  @objc fileprivate func renameSessionFromMenu(_ sender: NSMenuItem) {
+    guard let payload = payload(from: sender) else { return }
+    runRenameDialog(for: payload.session)
+  }
+
+  @objc fileprivate func restartSessionFromMenu(_ sender: NSMenuItem) {
+    guard let payload = payload(from: sender) else { return }
+    SessionManager.shared.restartSession(id: payload.session.id)
+  }
+
+  @objc fileprivate func closeSessionFromMenu(_ sender: NSMenuItem) {
+    guard let payload = payload(from: sender) else { return }
+    SessionManager.shared.closeSession(id: payload.session.id)
+  }
+
+  @objc fileprivate func openPRFromMenu(_ sender: NSMenuItem) {
+    guard let url = payload(from: sender)?.prURL else { return }
+    NSWorkspace.shared.open(url)
+  }
+
+  @objc fileprivate func copyWorktreePathFromMenu(_ sender: NSMenuItem) {
+    guard let path = payload(from: sender)?.session.worktreePath else { return }
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(path, forType: .string)
+  }
+
+  @objc fileprivate func removeSessionAndWorktreeFromMenu(_ sender: NSMenuItem) {
+    guard let session = payload(from: sender)?.session else { return }
+    guard let path = session.worktreePath else { return }
+    guard let repoRoot = WorktreeManager.managedRepoRoot(forWorktreePath: path) else { return }
+
+    let alert = NSAlert()
+    alert.messageText = "Remove Session and Worktree?"
+    alert.informativeText =
+      "This will close the session and remove the worktree at:\n\(path)\n\n"
+      + "Any uncommitted changes will be lost."
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: "Remove")
+    alert.addButton(withTitle: "Cancel")
+
+    guard let win = window else { return }
+    alert.beginSheetModal(for: win) { response in
+      guard response == .alertFirstButtonReturn else { return }
+      SessionManager.shared.closeSession(id: session.id)
+
+      DispatchQueue.global(qos: .userInitiated).async {
+        let result = Result {
+          try WorktreeManager.shared.removeWorktree(repoRoot: repoRoot, path: path)
+        }
+        DispatchQueue.main.async {
+          if case .failure(let error) = result {
+            let errAlert = NSAlert()
+            errAlert.messageText = "Remove Failed"
+            errAlert.informativeText = error.localizedDescription
+            errAlert.runModal()
+          }
+        }
+      }
+    }
+  }
+
+  /// Rename dialog for a session. Lives on the bar (not the card) so the
+  /// sheet's completion survives card rebuilds; `session` is retained by
+  /// the closure and updated in place.
+  fileprivate func runRenameDialog(for session: Session) {
+    let alert = NSAlert()
+    alert.messageText = "Rename Session"
+    alert.informativeText = "Enter a new name for \"\(session.name)\":"
+    alert.addButton(withTitle: "Rename")
+    alert.addButton(withTitle: "Cancel")
+
+    let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+    input.stringValue = session.name
+    alert.accessoryView = input
+
+    guard let win = window else { return }
+    alert.beginSheetModal(for: win) { response in
+      guard response == .alertFirstButtonReturn else { return }
+      let newName = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !newName.isEmpty else { return }
+      session.name = newName
+      NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+    }
+  }
+}
+
+/// Payload stored on a session card's menu items so the action handler on
+/// DFSessionBar still knows which session (and PR) the user right-clicked
+/// after the originating card has been rebuilt.
+private final class SessionCardMenuPayload: NSObject {
+  let session: Session
+  let prURL: URL?
+  init(session: Session, prURL: URL?) {
+    self.session = session
+    self.prURL = prURL
+  }
 }
 
 // MARK: - Session Card (Live Data)
@@ -198,15 +308,17 @@ final class SessionCard: NSView {
   private let session: Session
   private let index: Int
   private let isActive: Bool
+  private weak var bar: DFSessionBar?
   private var glowLayer: CALayer?
   private var mouseDownPoint: NSPoint?
   private var prPill: NSTextField?
   private var prURL: URL?
 
-  init(session: Session, isActive: Bool, index: Int) {
+  init(session: Session, isActive: Bool, index: Int, bar: DFSessionBar?) {
     self.session = session
     self.index = index
     self.isActive = isActive
+    self.bar = bar
     super.init(frame: .zero)
     translatesAutoresizingMaskIntoConstraints = false
     wantsLayer = true
@@ -298,104 +410,39 @@ final class SessionCard: NSView {
 
   private func makeContextMenu() -> NSMenu {
     let menu = NSMenu()
+    // Items target the bar with the session in `representedObject`, so the
+    // action still fires after this card has been rebuilt (see the actions'
+    // comment on DFSessionBar).
+    let payload = SessionCardMenuPayload(session: session, prURL: prURL)
     func add(_ title: String, _ action: Selector) {
       let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
-      item.target = self
+      item.target = bar
+      item.representedObject = payload
       menu.addItem(item)
     }
-    add("Rename Session…", #selector(doubleClicked))
-    add("Restart Session", #selector(restartFromMenu))
+    add("Rename Session…", #selector(DFSessionBar.renameSessionFromMenu(_:)))
+    add("Restart Session", #selector(DFSessionBar.restartSessionFromMenu(_:)))
     if prURL != nil || session.worktreePath != nil {
       menu.addItem(NSMenuItem.separator())
       if prURL != nil {
-        add("Open Pull Request", #selector(openPRFromMenu))
+        add("Open Pull Request", #selector(DFSessionBar.openPRFromMenu(_:)))
       }
       if session.worktreePath != nil {
-        add("Copy Worktree Path", #selector(copyWorktreePathFromMenu))
+        add("Copy Worktree Path", #selector(DFSessionBar.copyWorktreePathFromMenu(_:)))
       }
     }
     menu.addItem(NSMenuItem.separator())
-    add("Close Session", #selector(closeFromMenu))
+    add("Close Session", #selector(DFSessionBar.closeSessionFromMenu(_:)))
     if session.worktreePath != nil {
-      add("Remove Session and Worktree…", #selector(removeSessionAndWorktreeFromMenu))
+      add(
+        "Remove Session and Worktree…",
+        #selector(DFSessionBar.removeSessionAndWorktreeFromMenu(_:)))
     }
     return menu
   }
 
-  @objc private func restartFromMenu() {
-    SessionManager.shared.restartSession(id: session.id)
-  }
-
-  @objc private func closeFromMenu() {
-    SessionManager.shared.closeSession(id: session.id)
-  }
-
-  @objc private func removeSessionAndWorktreeFromMenu() {
-    guard let path = session.worktreePath else { return }
-    let subpath = WorktreeManager.worktreeSubpath + "/"
-    guard let range = path.range(of: subpath) else { return }
-    let repoRoot = String(path[..<range.lowerBound])
-
-    let alert = NSAlert()
-    alert.messageText = "Remove Session and Worktree?"
-    alert.informativeText =
-      "This will close the session and remove the worktree at:\n\(path)\n\n"
-      + "Any uncommitted changes will be lost."
-    alert.alertStyle = .warning
-    alert.addButton(withTitle: "Remove")
-    alert.addButton(withTitle: "Cancel")
-
-    guard let win = window else { return }
-    alert.beginSheetModal(for: win) { [weak self] response in
-      guard response == .alertFirstButtonReturn, let self = self else { return }
-      let sessionId = self.session.id
-      SessionManager.shared.closeSession(id: sessionId)
-
-      DispatchQueue.global(qos: .userInitiated).async {
-        let result = Result {
-          try WorktreeManager.shared.removeWorktree(repoRoot: repoRoot, path: path)
-        }
-        DispatchQueue.main.async {
-          if case .failure(let error) = result {
-            let errAlert = NSAlert()
-            errAlert.messageText = "Remove Failed"
-            errAlert.informativeText = error.localizedDescription
-            errAlert.runModal()
-          }
-        }
-      }
-    }
-  }
-
-  @objc private func openPRFromMenu() {
-    if let url = prURL { NSWorkspace.shared.open(url) }
-  }
-
-  @objc private func copyWorktreePathFromMenu() {
-    guard let path = session.worktreePath else { return }
-    NSPasteboard.general.clearContents()
-    NSPasteboard.general.setString(path, forType: .string)
-  }
-
   @objc private func doubleClicked() {
-    let alert = NSAlert()
-    alert.messageText = "Rename Session"
-    alert.informativeText = "Enter a new name for \"\(session.name)\":"
-    alert.addButton(withTitle: "Rename")
-    alert.addButton(withTitle: "Cancel")
-
-    let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-    input.stringValue = session.name
-    alert.accessoryView = input
-
-    guard let win = window else { return }
-    alert.beginSheetModal(for: win) { [weak self] response in
-      guard response == .alertFirstButtonReturn, let self = self else { return }
-      let newName = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !newName.isEmpty else { return }
-      self.session.name = newName
-      NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
-    }
+    bar?.runRenameDialog(for: session)
   }
 
   private func buildCard() {

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -560,8 +560,14 @@ final class DFSidebar: NSView {
           let branchName = wt.branch.isEmpty ? "detached" : wt.branch
           let isBase = wt.isBare
           // The primary worktree is the project root itself (not a child
-          // under .claude/worktrees/).
-          let isPrimary = !isBase && wt.path == project.path
+          // under .claude/worktrees/). Compare symlink-resolved paths: git
+          // reports realpaths (e.g. /private/var) while the project may have
+          // been added under an unresolved spelling.
+          let resolvedProjectPath =
+            URL(fileURLWithPath: project.path).resolvingSymlinksInPath().path
+          let isPrimary =
+            !isBase
+            && URL(fileURLWithPath: wt.path).resolvingSymlinksInPath().path == resolvedProjectPath
           let icon = isPrimary ? "circle.fill" : "arrow.triangle.branch"
           let detail = isBase ? "base" : nil
           let row = makeClickableRow(
@@ -598,8 +604,9 @@ final class DFSidebar: NSView {
             wtMenu.addItem(NSMenuItem.separator())
             // Rename only applies to draftframe-managed worktrees — the
             // primary checkout is the project root itself and can't be moved
-            // under .claude/worktrees/.
-            if !isPrimary {
+            // under .claude/worktrees/, and renaming a hand-made worktree
+            // would relocate it there out from under the user.
+            if !isPrimary && WorktreeManager.isManagedWorktree(wt.path) {
               let renameItem = NSMenuItem(
                 title: "Rename Worktree", action: #selector(renameWorktreeFromMenu(_:)),
                 keyEquivalent: "")

--- a/Sources/DraftFrameKit/DFStatusBar.swift
+++ b/Sources/DraftFrameKit/DFStatusBar.swift
@@ -22,6 +22,17 @@ final class DFStatusBar: NSView {
   private var micIndicator: NSImageView!
   private var refreshTimer: Timer?
 
+  // Concurrent so a git that hangs (dead network mount, wedged fsmonitor)
+  // can't wedge the recovery lookup behind it on a serial queue.
+  private let branchQueue = DispatchQueue(
+    label: "com.draftframe.statusbar.branch", qos: .utility, attributes: .concurrent)
+  private var branchRefreshInFlight = false
+  private var branchRefreshStartedAt = Date.distantPast
+  private var branchRefreshGeneration = 0
+  /// After this long, an in-flight lookup is presumed hung and a new one may
+  /// start; the hung git keeps its thread but the label recovers.
+  private static let branchRefreshTimeout: TimeInterval = 10
+
   override init(frame: NSRect) {
     super.init(frame: frame)
     wantsLayer = true
@@ -132,12 +143,43 @@ final class DFStatusBar: NSView {
     micIndicator.isHidden = !VoiceManager.shared.isListening
   }
 
+  /// Resolve the branch off the main thread: `refresh()` runs on every
+  /// `.sessionsDidChange` tick (~40x/min while an agent works) and spawning
+  /// git synchronously there blocks event delivery — on a cold or busy repo
+  /// long enough to beachball. At most one lookup is in flight; ticks that
+  /// arrive mid-lookup are dropped (the next tick re-checks anyway).
+  private func refreshBranchAsync() {
+    let now = Date()
+    if branchRefreshInFlight,
+      now.timeIntervalSince(branchRefreshStartedAt) < Self.branchRefreshTimeout
+    {
+      return
+    }
+    branchRefreshInFlight = true
+    branchRefreshStartedAt = now
+    branchRefreshGeneration += 1
+    let generation = branchRefreshGeneration
+    let dir = SessionManager.shared.branchLookupDirectory
+    branchQueue.async { [weak self] in
+      let branch = SessionManager.shared.currentBranch(inDirectory: dir)
+      DispatchQueue.main.async {
+        guard let self else { return }
+        // A presumed-hung lookup that eventually returns must not clear a
+        // newer lookup's flag or overwrite its result.
+        guard generation == self.branchRefreshGeneration else { return }
+        self.branchRefreshInFlight = false
+        // The active session may have changed mid-lookup; drop stale results.
+        guard dir == SessionManager.shared.branchLookupDirectory else { return }
+        self.branchLabel.stringValue = branch
+      }
+    }
+  }
+
   @objc private func refresh() {
     let mgr = SessionManager.shared
 
     // Branch from active session
-    let branch = mgr.currentBranch()
-    branchLabel.stringValue = branch
+    refreshBranchAsync()
 
     // Active model
     if let session = mgr.activeSession {

--- a/Sources/DraftFrameKit/PRMonitor.swift
+++ b/Sources/DraftFrameKit/PRMonitor.swift
@@ -129,6 +129,10 @@ final class PRMonitor {
   /// One poll timer per session.
   private var timers: [UUID: DispatchSourceTimer] = [:]
 
+  /// Path each timer's event handler captured at start, so a session whose
+  /// worktree moved (rename) gets its timer restarted on the new path.
+  private var timerPaths: [UUID: String] = [:]
+
   private let queue = DispatchQueue(label: "com.draftframe.pr-monitor", qos: .utility)
 
   /// How often to hit `gh pr view` per session.
@@ -204,8 +208,14 @@ final class PRMonitor {
     // since the child shell inherits that cwd at launch. Sessions created
     // with neither (shouldn't happen in practice) are skipped.
     for session in sessions {
-      guard timers[session.id] == nil else { continue }
       guard let path = Self.effectivePath(for: session) else { continue }
+      // The timer's event handler captured its path at start; if the
+      // session's worktree has since moved (rename), restart on the new one.
+      if timers[session.id] != nil, timerPaths[session.id] != path {
+        timers[session.id]?.cancel()
+        timers.removeValue(forKey: session.id)
+      }
+      guard timers[session.id] == nil else { continue }
       startTimer(sessionID: session.id, worktreePath: path)
     }
 
@@ -213,6 +223,7 @@ final class PRMonitor {
     for id in timers.keys where !currentIDs.contains(id) {
       timers[id]?.cancel()
       timers.removeValue(forKey: id)
+      timerPaths.removeValue(forKey: id)
       statusBySession.removeValue(forKey: id)
       lastFailureFiredAt.removeValue(forKey: id)
       mergedAttempted.remove(id)
@@ -231,6 +242,7 @@ final class PRMonitor {
     }
     timer.resume()
     timers[sessionID] = timer
+    timerPaths[sessionID] = worktreePath
   }
 
   // MARK: - Polling (runs on `queue`)

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -71,9 +71,7 @@ final class Session {
   var displayName: String {
     guard name == "main" || name == "master" else { return name }
     guard let path = worktreePath else { return name }
-    let subpath = WorktreeManager.worktreeSubpath + "/"
-    if let range = path.range(of: subpath) {
-      let projectRoot = String(path[..<range.lowerBound])
+    if let projectRoot = WorktreeManager.managedRepoRoot(forWorktreePath: path) {
       return (projectRoot as NSString).lastPathComponent
     }
     return (path as NSString).lastPathComponent
@@ -474,7 +472,16 @@ final class SessionManager {
   /// on disk: adopt the new name and path, and re-point the transcript and
   /// status watchers at the new directory.
   func worktreeRenamed(from oldPath: String, to newPath: String, newName: String) {
-    guard let session = sessions.first(where: { $0.worktreePath == oldPath }) else { return }
+    // Match on symlink-resolved paths: callers pass git's realpath spelling
+    // (e.g. /private/var) while the session may hold the unresolved one.
+    let resolvedOld = URL(fileURLWithPath: oldPath).resolvingSymlinksInPath().path
+    guard
+      let session = sessions.first(where: { s in
+        guard let p = s.worktreePath else { return false }
+        return p == oldPath
+          || URL(fileURLWithPath: p).resolvingSymlinksInPath().path == resolvedOld
+      })
+    else { return }
     session.name = newName
     session.worktreePath = newPath
     session.stopWatchers()
@@ -519,9 +526,16 @@ final class SessionManager {
     createSession(name: old.name, worktreePath: old.worktreePath, agent: old.agent)
   }
 
-  /// Get the current git branch for the active session's directory.
-  func currentBranch() -> String {
-    let dir = activeSession?.worktreePath ?? FileManager.default.currentDirectoryPath
+  /// Directory whose git branch the status bar should show. Read on the
+  /// main thread; the actual `git` spawn happens off-main via
+  /// `currentBranch(inDirectory:)`.
+  var branchLookupDirectory: String {
+    activeSession?.worktreePath ?? FileManager.default.currentDirectoryPath
+  }
+
+  /// Get the current git branch for `dir`. Spawns git and blocks until it
+  /// exits, so call from a background queue.
+  func currentBranch(inDirectory dir: String) -> String {
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
     proc.arguments = ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]

--- a/Sources/DraftFrameKit/WorktreeManager.swift
+++ b/Sources/DraftFrameKit/WorktreeManager.swift
@@ -30,6 +30,17 @@ final class WorktreeManager {
     return resolved.contains(worktreeSubpath + "/")
   }
 
+  /// Repo root that owns a managed worktree path. Matches the LAST
+  /// `/.claude/worktrees/` occurrence: a managed worktree can itself contain
+  /// managed worktrees, and a first-occurrence match would resolve a nested
+  /// worktree to the outermost repo. Nil when the path isn't managed.
+  static func managedRepoRoot(forWorktreePath path: String) -> String? {
+    guard let range = path.range(of: worktreeSubpath + "/", options: .backwards) else {
+      return nil
+    }
+    return String(path[..<range.lowerBound])
+  }
+
   /// Resolve the git repo root for an arbitrary path.
   static func repoRoot(at path: String) -> String? {
     let proc = Process()
@@ -433,11 +444,13 @@ final class WorktreeManager {
     }
     let newPath = root + Self.worktreeSubpath + "/" + name
     // Compare symlink-resolved paths: git reports realpaths (e.g. /private/var
-    // on macOS) while callers may hold the unresolved spelling.
+    // on macOS) while callers may hold the unresolved spelling. When the
+    // directory already matches, the branch may still need renaming (slash
+    // branches live in dash-named directories), so only skip the move.
     let resolvedNew = URL(fileURLWithPath: newPath).resolvingSymlinksInPath().path
     let resolvedOld = URL(fileURLWithPath: worktree.path).resolvingSymlinksInPath().path
-    guard resolvedNew != resolvedOld else { return worktree.path }
-    guard !FileManager.default.fileExists(atPath: newPath) else {
+    let directoryAlreadyMatches = resolvedNew == resolvedOld
+    guard directoryAlreadyMatches || !FileManager.default.fileExists(atPath: newPath) else {
       throw WorktreeError.renameFailed("\(newPath) already exists.")
     }
 
@@ -450,6 +463,8 @@ final class WorktreeManager {
         throw WorktreeError.renameFailed(err)
       }
     }
+
+    if directoryAlreadyMatches { return worktree.path }
 
     if let err = runGit(["-C", root, "worktree", "move", worktree.path, newPath], in: root) {
       // Best-effort roll back the branch rename so a failed move doesn't


### PR DESCRIPTION
Fixes #13.

## Session card context-menu fix (#13)

Session card menu items now target the session bar instead of the card. Cards are torn down and rebuilt on every `.sessionsDidChange` tick (~1.5s while an agent works), and `NSMenuItem` holds its target weakly, so any rebuild while a menu or confirmation sheet was open silently dropped the action (Remove Session and Worktree, Rename, etc.). The bar lives as long as the window, and each item retains its `Session` via `representedObject`.

## Code-review hardening

A review of the diff surfaced several adjacent bugs, fixed here:

- **Wrong repo root for nested managed worktrees**: deriving the repo root from the *first* `.claude/worktrees/` occurrence could target the wrong repo for a nested managed checkout, where the removal failure path would then force-delete a same-named branch in that repo. Added `WorktreeManager.managedRepoRoot(forWorktreePath:)` (last-occurrence match) and used it in both the remove action and `Session.displayName`.
- **Rename offered for unmanaged worktrees**: the sidebar's Rename Worktree item now requires `isManagedWorktree`, so a hand-made worktree can't be silently relocated under `.claude/worktrees/`. The primary-checkout test also compares symlink-resolved paths.
- **Branch rename skipped for slash-named branches**: `renameWorktree`'s same-path early return ran before `git branch -m`, so a branch like `feature/foo` (directory `feature-foo`) could report a successful rename that never happened. The branch rename now runs first; only the `worktree move` is skipped.
- **PRMonitor frozen after a worktree rename**: each poll timer captured its path at start and was never re-keyed. PRMonitor now restarts a session's timer when its effective path changes.
- **Status bar branch label could freeze forever**: one hung `git` (dead network mount, wedged fsmonitor) left `branchRefreshInFlight` set for the app's lifetime. The guard now expires after 10s, the lookup queue is concurrent so recovery can't queue behind the hung call, a generation counter keeps late results from clobbering newer ones, and results for a no-longer-current directory are dropped.
- **Symlinked project paths**: `worktreeRenamed` matches sessions by symlink-resolved path, so a rename still updates the session when the stored spelling differs from git's realpath.

Not addressed (needs a product call): renaming a worktree while its agent is running re-points watchers away from the live transcript; the running process keeps writing under its old cwd.

Build, all 124 tests, and `swift-format lint --strict` pass.