### PR TITLE
Keep quick terminal visible when the app loses focus

### DIFF
--- a/Sources/DraftFrameKit/DFQuickTerminal.swift
+++ b/Sources/DraftFrameKit/DFQuickTerminal.swift
@@ -138,10 +138,11 @@ final class DFQuickTerminal {
     win.titleVisibility = .hidden
     win.backgroundColor = Theme.bg
     win.isMovableByWindowBackground = false
-    // Stay on screen when the app deactivates, and float above other apps'
-    // windows, so the terminal can be referenced while working elsewhere.
+    // Stay on screen when the app deactivates so the quick terminal's
+    // visibility tracks the main window's: at normal level both are covered
+    // or revealed together rather than the terminal vanishing on app switch.
     win.hidesOnDeactivate = false
-    win.level = .floating
+    win.level = .normal
     win.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     win.isReleasedWhenClosed = false
     win.minSize = NSSize(width: 500, height: 200)

--- a/Sources/DraftFrameKit/DFQuickTerminal.swift
+++ b/Sources/DraftFrameKit/DFQuickTerminal.swift
@@ -138,8 +138,10 @@ final class DFQuickTerminal {
     win.titleVisibility = .hidden
     win.backgroundColor = Theme.bg
     win.isMovableByWindowBackground = false
-    win.hidesOnDeactivate = true
-    win.level = .normal
+    // Stay on screen when the app deactivates, and float above other apps'
+    // windows, so the terminal can be referenced while working elsewhere.
+    win.hidesOnDeactivate = false
+    win.level = .floating
     win.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     win.isReleasedWhenClosed = false
     win.minSize = NSSize(width: 500, height: 200)


### PR DESCRIPTION
Fixes #17

The quick terminal window was created with `hidesOnDeactivate = true`, so AppKit ordered it out whenever focus moved to another app.

Setting `hidesOnDeactivate = false` keeps it on screen at normal window level, so its visual presence stays synced with the main window: when DraftFrame is visible while another app has focus, the quick terminal is visible too, and both get covered or revealed together.

Cmd+` still toggles it explicitly as before.