### PR TITLE
Add sort menu to the projects header

### DIFF
--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -189,6 +189,16 @@ final class DFSidebar: NSView {
     openProjectBtn.translatesAutoresizingMaskIntoConstraints = false
     contentView.addSubview(openProjectBtn)
 
+    let sortBtn = NSButton(title: "", target: self, action: #selector(sortButtonClicked(_:)))
+    sortBtn.image = NSImage(
+      systemSymbolName: "arrow.up.arrow.down", accessibilityDescription: "Sort Projects")
+    sortBtn.isBordered = false
+    sortBtn.imageScaling = .scaleProportionallyDown
+    sortBtn.contentTintColor = Theme.text3
+    sortBtn.toolTip = "Sort Projects"
+    sortBtn.translatesAutoresizingMaskIntoConstraints = false
+    contentView.addSubview(sortBtn)
+
     worktreeStack.orientation = .vertical
     worktreeStack.spacing = 2
     worktreeStack.alignment = .leading
@@ -266,6 +276,11 @@ final class DFSidebar: NSView {
       openProjectBtn.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
       openProjectBtn.widthAnchor.constraint(equalToConstant: 16),
       openProjectBtn.heightAnchor.constraint(equalToConstant: 16),
+
+      sortBtn.centerYAnchor.constraint(equalTo: projectHeader.centerYAnchor),
+      sortBtn.trailingAnchor.constraint(equalTo: openProjectBtn.leadingAnchor, constant: -8),
+      sortBtn.widthAnchor.constraint(equalToConstant: 16),
+      sortBtn.heightAnchor.constraint(equalToConstant: 16),
 
       worktreeStack.topAnchor.constraint(equalTo: projectHeader.bottomAnchor, constant: 6),
       worktreeStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
@@ -345,6 +360,49 @@ final class DFSidebar: NSView {
 
   // MARK: - Worktrees
 
+  /// Projects in the user's chosen sort order. "Active sessions" means the
+  /// project has at least one open session rooted at the project itself or
+  /// at a worktree beneath it (paths compared symlink-resolved, since git
+  /// and session bookkeeping report realpaths).
+  private func sortedProjects() -> [ProjectManager.Project] {
+    let projects = ProjectManager.shared.projects
+    var activePaths: Set<String> = []
+    if ProjectManager.shared.sortOrder == .activeSessions {
+      let sessionPaths = SessionManager.shared.sessions.compactMap { s in
+        s.worktreePath.map { URL(fileURLWithPath: $0).resolvingSymlinksInPath().path }
+      }
+      for project in projects {
+        let root = URL(fileURLWithPath: project.path).resolvingSymlinksInPath().path
+        if sessionPaths.contains(where: { $0 == root || $0.hasPrefix(root + "/") }) {
+          activePaths.insert(project.path)
+        }
+      }
+    }
+    return ProjectManager.shared.sortedProjects(activeProjectPaths: activePaths)
+  }
+
+  @objc private func sortButtonClicked(_ sender: NSButton) {
+    let menu = NSMenu()
+    let current = ProjectManager.shared.sortOrder
+    for order in ProjectManager.SortOrder.allCases {
+      let item = NSMenuItem(
+        title: order.displayName, action: #selector(sortOrderSelected(_:)), keyEquivalent: "")
+      item.target = self
+      item.representedObject = order.rawValue
+      item.state = (order == current) ? .on : .off
+      menu.addItem(item)
+    }
+    menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.maxY + 4), in: sender)
+  }
+
+  @objc private func sortOrderSelected(_ sender: NSMenuItem) {
+    guard let raw = sender.representedObject as? String,
+      let order = ProjectManager.SortOrder(rawValue: raw)
+    else { return }
+    ProjectManager.shared.sortOrder = order
+    refreshWorktrees()
+  }
+
   @objc func refreshWorktrees() {
     // Process.waitUntilExit() inside getWorktrees(for:) pumps the run loop,
     // which can dispatch a queued .sessionsDidChange notification and re-enter
@@ -360,7 +418,7 @@ final class DFSidebar: NSView {
     isRefreshingWorktrees = true
     defer { isRefreshingWorktrees = false }
 
-    let projects = ProjectManager.shared.projects
+    let projects = sortedProjects()
     let activeDir = SessionManager.shared.projectDir
 
     // Always fetch every project's worktrees, including collapsed ones, so
@@ -428,7 +486,7 @@ final class DFSidebar: NSView {
       return
     }
 
-    for (idx, project) in projects.enumerated() {
+    for project in projects {
       let isActive = project.path == activeDir
 
       // Project header row — clickable to expand/collapse. Chevron icon is
@@ -456,7 +514,6 @@ final class DFSidebar: NSView {
       addBtn.contentTintColor = Theme.text3
       addBtn.toolTip = "New worktree in \(project.name)"
       addBtn.translatesAutoresizingMaskIntoConstraints = false
-      addBtn.tag = idx
       projectRow.addSubview(addBtn)
       NSLayoutConstraint.activate([
         addBtn.trailingAnchor.constraint(equalTo: projectRow.trailingAnchor),
@@ -913,16 +970,17 @@ final class DFSidebar: NSView {
   }
 
   @objc private func addWorktreeForProject(_ sender: NSButton) {
-    let projects = ProjectManager.shared.projects
-    guard sender.tag >= 0, sender.tag < projects.count else { return }
-    let project = projects[sender.tag]
+    // The button lives inside the project's ClickableRow; read the path from
+    // there rather than indexing into the (sort-order-dependent) project list.
+    guard let row = sender.superview as? ClickableRow, let path = row.worktreePath else { return }
+    let name = (path as NSString).lastPathComponent
 
     guard let win = window else { return }
     NewWorktreeDialog.present(
       on: win, title: "New Worktree",
-      message: "Create a worktree in \(project.name)."
+      message: "Create a worktree in \(name)."
     ) { result in
-      self.handleWorktreeDialogResult(result, repoRoot: project.path)
+      self.handleWorktreeDialogResult(result, repoRoot: path)
     }
   }
 

--- a/Sources/DraftFrameKit/ProjectManager.swift
+++ b/Sources/DraftFrameKit/ProjectManager.swift
@@ -12,9 +12,70 @@ final class ProjectManager {
     var name: String { (path as NSString).lastPathComponent }
   }
 
+  /// How the sidebar orders the project list.
+  enum SortOrder: String, CaseIterable {
+    case recent
+    case activeSessions
+    case nameAscending
+    case nameDescending
+
+    var displayName: String {
+      switch self {
+      case .recent: return "Recent"
+      case .activeSessions: return "Active Sessions"
+      case .nameAscending: return "A-Z"
+      case .nameDescending: return "Z-A"
+      }
+    }
+  }
+
   private(set) var projects: [Project] = []
 
   private static let configPath = NSHomeDirectory() + "/.config/draftframe/projects.json"
+  private static let sortOrderKey = "DFProjectSortOrder"
+
+  var sortOrder: SortOrder {
+    get {
+      SortOrder(rawValue: UserDefaults.standard.string(forKey: Self.sortOrderKey) ?? "")
+        ?? .recent
+    }
+    set { UserDefaults.standard.set(newValue.rawValue, forKey: Self.sortOrderKey) }
+  }
+
+  /// Projects in the persisted sort order. The stored array is already
+  /// most-recently-opened first, so `.recent` returns it as-is; the other
+  /// orders are stable reorderings of it (ties keep recency order).
+  func sortedProjects(activeProjectPaths: Set<String> = []) -> [Project] {
+    Self.sort(projects, by: sortOrder, activeProjectPaths: activeProjectPaths)
+  }
+
+  static func sort(
+    _ projects: [Project], by order: SortOrder, activeProjectPaths: Set<String>
+  ) -> [Project] {
+    switch order {
+    case .recent:
+      return projects
+    case .activeSessions:
+      return projects.filter { activeProjectPaths.contains($0.path) }
+        + projects.filter { !activeProjectPaths.contains($0.path) }
+    case .nameAscending:
+      return projects.enumerated().sorted {
+        switch $0.element.name.localizedCaseInsensitiveCompare($1.element.name) {
+        case .orderedAscending: return true
+        case .orderedDescending: return false
+        case .orderedSame: return $0.offset < $1.offset
+        }
+      }.map { $0.element }
+    case .nameDescending:
+      return projects.enumerated().sorted {
+        switch $0.element.name.localizedCaseInsensitiveCompare($1.element.name) {
+        case .orderedAscending: return false
+        case .orderedDescending: return true
+        case .orderedSame: return $0.offset < $1.offset
+        }
+      }.map { $0.element }
+    }
+  }
 
   private init() {
     load()

--- a/Tests/DraftFrameTests/ProjectSortTests.swift
+++ b/Tests/DraftFrameTests/ProjectSortTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+final class ProjectSortTests: XCTestCase {
+
+  private func projects(_ paths: [String]) -> [ProjectManager.Project] {
+    paths.map { ProjectManager.Project(path: $0, isExpanded: true) }
+  }
+
+  func testRecentKeepsStoredOrder() {
+    let input = projects(["/a/zebra", "/a/apple", "/a/mango"])
+    let sorted = ProjectManager.sort(input, by: .recent, activeProjectPaths: [])
+    XCTAssertEqual(sorted.map { $0.path }, ["/a/zebra", "/a/apple", "/a/mango"])
+  }
+
+  func testNameAscendingSortsCaseInsensitively() {
+    let input = projects(["/a/zebra", "/a/Apple", "/a/mango"])
+    let sorted = ProjectManager.sort(input, by: .nameAscending, activeProjectPaths: [])
+    XCTAssertEqual(sorted.map { $0.name }, ["Apple", "mango", "zebra"])
+  }
+
+  func testNameDescending() {
+    let input = projects(["/a/apple", "/a/zebra", "/a/mango"])
+    let sorted = ProjectManager.sort(input, by: .nameDescending, activeProjectPaths: [])
+    XCTAssertEqual(sorted.map { $0.name }, ["zebra", "mango", "apple"])
+  }
+
+  func testNameSortIsStableForEqualNames() {
+    let input = projects(["/first/repo", "/second/repo", "/a/apple"])
+    let sorted = ProjectManager.sort(input, by: .nameAscending, activeProjectPaths: [])
+    XCTAssertEqual(sorted.map { $0.path }, ["/a/apple", "/first/repo", "/second/repo"])
+  }
+
+  func testActiveSessionsFloatToTopKeepingRecencyWithinGroups() {
+    let input = projects(["/a/one", "/a/two", "/a/three", "/a/four"])
+    let sorted = ProjectManager.sort(
+      input, by: .activeSessions, activeProjectPaths: ["/a/three", "/a/two"])
+    XCTAssertEqual(sorted.map { $0.path }, ["/a/two", "/a/three", "/a/one", "/a/four"])
+  }
+
+  func testSortOrderDisplayNames() {
+    XCTAssertEqual(ProjectManager.SortOrder.recent.displayName, "Recent")
+    XCTAssertEqual(ProjectManager.SortOrder.activeSessions.displayName, "Active Sessions")
+    XCTAssertEqual(ProjectManager.SortOrder.nameAscending.displayName, "A-Z")
+    XCTAssertEqual(ProjectManager.SortOrder.nameDescending.displayName, "Z-A")
+  }
+}


### PR DESCRIPTION
Closes #19.

Adds a sort button on the PROJECT header row, next to the Open Project button. Clicking it pops a menu with the current option checked:

- **Recent** - most recently opened projects first (the existing order; remains the default)
- **Active Sessions** - projects with at least one open session (at the project root or any worktree beneath it) float to the top, keeping recency order within each group
- **A-Z** / **Z-A** - case-insensitive alphabetical by project name, stable for equal names

The selection persists across launches via UserDefaults (`DFProjectSortOrder`). Sorting is a pure static function on `ProjectManager`, covered by unit tests.

Also fixes a latent issue this change would have exposed: the per-project "new worktree" button located its project by index into the unsorted list; it now reads the project path from its own row, so reordering can't point it at the wrong project.