### PR TITLE
Concurrency overhaul: main-actor isolation, typed session events, shared status actor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,13 @@ let package = Package(
         .target(
             name: "DraftFrameKit",
             dependencies: ["SwiftTerm"],
-            path: "Sources/DraftFrameKit"
+            path: "Sources/DraftFrameKit",
+            swiftSettings: [
+                // Surface data-race hazards as warnings (Swift 5 language
+                // mode never promotes these to errors). Inventory for the
+                // incremental actor migration; see git history for context.
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
         .executableTarget(
             name: "DraftFrame",

--- a/Sources/DraftFrame/main.swift
+++ b/Sources/DraftFrame/main.swift
@@ -1,7 +1,13 @@
 import AppKit
 import DraftFrameKit
 
-let app = NSApplication.shared
-let delegate = DFAppDelegate()
-app.delegate = delegate
-app.run()
+// The process entry point runs on the main thread, but top-level code in a
+// literal main.swift is not statically main-actor isolated — assert it so the
+// @MainActor app delegate can be constructed. `run()` doesn't return until
+// quit, keeping `delegate` alive (NSApplication.delegate doesn't retain).
+MainActor.assumeIsolated {
+  let app = NSApplication.shared
+  let delegate = DFAppDelegate()
+  app.delegate = delegate
+  app.run()
+}

--- a/Sources/DraftFrameKit/AppSettings.swift
+++ b/Sources/DraftFrameKit/AppSettings.swift
@@ -4,7 +4,9 @@ import Foundation
 /// worktrees; explicit per-worktree toggles (sidebar PR action rows) and
 /// per-watchdog edits still override them.
 enum AppSettings {
-  private static let defaults = UserDefaults.standard
+  // UserDefaults is documented thread-safe; the annotation just tells the
+  // compiler so.
+  private nonisolated(unsafe) static let defaults = UserDefaults.standard
 
   private static let autoFixKey = "DFDefaultPRAutoFix"
   private static let autoMergeKey = "DFDefaultPRAutoMerge"

--- a/Sources/DraftFrameKit/ClaudeTerminalView.swift
+++ b/Sources/DraftFrameKit/ClaudeTerminalView.swift
@@ -1125,9 +1125,12 @@ class ClaudeTerminalView: LocalProcessTerminalView {
     // as [Image #N], and attaches other files as context.
     let text = paths.joined(separator: " ")
     if terminal.bracketedPasteMode {
-      send(data: EscapeSequences.bracketedPasteStart[0...])
+      // ESC [ 200~ … ESC [ 201~ — inlined rather than referencing
+      // SwiftTerm's EscapeSequences statics, which are declared as mutable
+      // global state and trip strict-concurrency checking.
+      send(data: Array("\u{1b}[200~".utf8)[0...])
       send(txt: text)
-      send(data: EscapeSequences.bracketedPasteEnd[0...])
+      send(data: Array("\u{1b}[201~".utf8)[0...])
     } else {
       send(txt: text)
     }

--- a/Sources/DraftFrameKit/CodexUsageWatcher.swift
+++ b/Sources/DraftFrameKit/CodexUsageWatcher.swift
@@ -17,7 +17,9 @@ import Foundation
 ///     session's working/idle state.
 ///   - `turn_context`: the model in effect for the turn (users can switch
 ///     mid-session with /model).
-final class CodexUsageWatcher: UsageWatcher {
+/// `@unchecked Sendable`: mutable state is confined to the tailer's serial
+/// queue, except the assistant-text pair, which is lock-guarded.
+final class CodexUsageWatcher: UsageWatcher, @unchecked Sendable {
 
   // MARK: - Model pricing per token (derived from per-1M-token rates)
 
@@ -148,7 +150,7 @@ final class CodexUsageWatcher: UsageWatcher {
   // MARK: - Private
 
   private let onUpdate: SessionJSONLWatcher.UpdateCallback
-  private let onTurnState: ((SessionState) -> Void)?
+  private let onTurnState: (@MainActor (SessionState) -> Void)?
   private let workingDirectory: String
   /// Symlink-resolved `workingDirectory`, matched against each rollout's
   /// (also resolved) `session_meta.cwd` — codex records its getcwd realpath,
@@ -178,7 +180,7 @@ final class CodexUsageWatcher: UsageWatcher {
   init(
     workingDirectory: String,
     sessionsRoot: String = NSHomeDirectory() + "/.codex/sessions",
-    onTurnState: ((SessionState) -> Void)? = nil,
+    onTurnState: (@MainActor (SessionState) -> Void)? = nil,
     onUpdate: @escaping SessionJSONLWatcher.UpdateCallback
   ) {
     self.workingDirectory = workingDirectory
@@ -331,7 +333,9 @@ final class CodexUsageWatcher: UsageWatcher {
     let lifeIn = lifetimeBaseTokensIn + totalTokensIn
     let lifeOut = lifetimeBaseTokensOut + totalTokensOut
     DispatchQueue.main.async { [weak self] in
-      self?.onUpdate(cost, tIn, tOut, model, ctx, maxCtx, lifeCost, lifeIn, lifeOut)
+      MainActor.assumeIsolated {
+        self?.onUpdate(cost, tIn, tOut, model, ctx, maxCtx, lifeCost, lifeIn, lifeOut)
+      }
     }
   }
 
@@ -339,7 +343,9 @@ final class CodexUsageWatcher: UsageWatcher {
     guard let state = latestTurnState, state != lastReportedTurnState else { return }
     lastReportedTurnState = state
     DispatchQueue.main.async { [weak self] in
-      self?.onTurnState?(state)
+      MainActor.assumeIsolated {
+        self?.onTurnState?(state)
+      }
     }
   }
 

--- a/Sources/DraftFrameKit/CodexUsageWatcher.swift
+++ b/Sources/DraftFrameKit/CodexUsageWatcher.swift
@@ -129,8 +129,13 @@ final class CodexUsageWatcher: UsageWatcher {
   private(set) var parsedMaxContextTokens: Int = 0
 
   /// Most recent assistant message, for the dashboard's summary view.
-  private(set) var latestAssistantText: String?
-  private(set) var latestAssistantAt: Date?
+  /// Written on the tailer's queue but read from the main thread, so access
+  /// goes through a lock (same rationale as SessionJSONLWatcher's pair).
+  var latestAssistantText: String? { assistantTextLock.withLock { _latestAssistantText } }
+  var latestAssistantAt: Date? { assistantTextLock.withLock { _latestAssistantAt } }
+  private let assistantTextLock = NSLock()
+  private var _latestAssistantText: String?
+  private var _latestAssistantAt: Date?
 
   /// Session state derived from the rollout's persisted turn lifecycle
   /// events (`turn_started` → generating, `turn_complete`/`turn_aborted` →
@@ -145,6 +150,10 @@ final class CodexUsageWatcher: UsageWatcher {
   private let onUpdate: SessionJSONLWatcher.UpdateCallback
   private let onTurnState: ((SessionState) -> Void)?
   private let workingDirectory: String
+  /// Symlink-resolved `workingDirectory`, matched against each rollout's
+  /// (also resolved) `session_meta.cwd` — codex records its getcwd realpath,
+  /// while the session may hold an unresolved spelling like /tmp.
+  private let resolvedWorkingDirectory: String
   /// Root of codex's session store (`~/.codex/sessions` in production).
   private let sessionsRoot: String
   private var tailer: JSONLTailer?
@@ -173,6 +182,8 @@ final class CodexUsageWatcher: UsageWatcher {
     onUpdate: @escaping SessionJSONLWatcher.UpdateCallback
   ) {
     self.workingDirectory = workingDirectory
+    self.resolvedWorkingDirectory =
+      URL(fileURLWithPath: workingDirectory).resolvingSymlinksInPath().path
     self.sessionsRoot = sessionsRoot
     self.onTurnState = onTurnState
     self.onUpdate = onUpdate
@@ -235,7 +246,7 @@ final class CodexUsageWatcher: UsageWatcher {
           let mod = try? url.resourceValues(forKeys: [.contentModificationDateKey])
             .contentModificationDate,
           mod > newestDate,
-          rolloutCwd(of: url.path) == workingDirectory
+          rolloutCwd(of: url.path) == resolvedWorkingDirectory
         else { continue }
         newestDate = mod
         newest = url.path
@@ -274,8 +285,12 @@ final class CodexUsageWatcher: UsageWatcher {
         cwd = obj["cwd"] as? String
       }
     }
-    cwdCache[path] = cwd
-    return cwd
+    // Cache the symlink-resolved spelling so the compare against
+    // `resolvedWorkingDirectory` matches regardless of which spelling
+    // codex recorded (its getcwd writes the realpath).
+    let resolved = cwd.map { URL(fileURLWithPath: $0).resolvingSymlinksInPath().path }
+    cwdCache[path] = resolved
+    return resolved
   }
 
   // MARK: - Line processing
@@ -414,8 +429,10 @@ final class CodexUsageWatcher: UsageWatcher {
     guard let message = payload["message"] as? String,
       !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     else { return false }
-    latestAssistantText = message
-    latestAssistantAt = Date()
+    assistantTextLock.withLock {
+      _latestAssistantText = message
+      _latestAssistantAt = Date()
+    }
     return true
   }
 }

--- a/Sources/DraftFrameKit/DFAppDelegate.swift
+++ b/Sources/DraftFrameKit/DFAppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 
+@MainActor
 public final class DFAppDelegate: NSObject, NSApplicationDelegate {
   var windowController: DFWindowController?
 

--- a/Sources/DraftFrameKit/DFDashboard.swift
+++ b/Sources/DraftFrameKit/DFDashboard.swift
@@ -23,14 +23,17 @@ final class DFDashboard: NSView {
     isHidden = true
     setupUI()
 
-    NotificationCenter.default.addObserver(
-      self, selector: #selector(sessionsChanged),
-      name: .sessionsDidChange, object: nil
-    )
-    NotificationCenter.default.addObserver(
-      self, selector: #selector(sessionsChanged),
-      name: .prStatusDidChange, object: nil
-    )
+    // The dashboard renders list, state, and usage, so it subscribes to all
+    // three — but its handler is already a no-op while hidden.
+    for name: Notification.Name in [
+      .sessionListDidChange, .sessionStateDidChange, .sessionUsageDidChange,
+      .prStatusDidChange,
+    ] {
+      NotificationCenter.default.addObserver(
+        self, selector: #selector(sessionsChanged),
+        name: name, object: nil
+      )
+    }
   }
 
   @available(*, unavailable)

--- a/Sources/DraftFrameKit/DFDiffOverlay.swift
+++ b/Sources/DraftFrameKit/DFDiffOverlay.swift
@@ -25,7 +25,9 @@ final class DFDiffOverlay: NSView {
   private var currentIndex = 0
 
   /// Local key monitor that catches Esc / Up / Down while the overlay is visible.
-  private var keyMonitor: Any?
+  /// `nonisolated(unsafe)` so the (never-raced) removal in deinit compiles;
+  /// every other access is on the main actor.
+  private nonisolated(unsafe) var keyMonitor: Any?
 
   override init(frame: NSRect) {
     super.init(frame: frame)
@@ -167,7 +169,9 @@ final class DFDiffOverlay: NSView {
     }
   }
 
-  private func removeKeyMonitor() {
+  /// `nonisolated` so deinit can call it; NSEvent.removeMonitor is
+  /// thread-safe and `keyMonitor` is nonisolated(unsafe) for the same reason.
+  private nonisolated func removeKeyMonitor() {
     if let m = keyMonitor {
       NSEvent.removeMonitor(m)
       keyMonitor = nil

--- a/Sources/DraftFrameKit/DFQuickTerminal.swift
+++ b/Sources/DraftFrameKit/DFQuickTerminal.swift
@@ -8,6 +8,7 @@ import SwiftTerm
 /// visible/focused. Shells persist across show/hide, tab switches, and
 /// session switches, so scrollback and in-flight commands survive all of
 /// that until the shell itself exits.
+@MainActor
 final class DFQuickTerminal {
   static let shared = DFQuickTerminal()
 
@@ -799,7 +800,10 @@ final class DFQuickTerminal {
     loads[paneID]?.maxTimer = Timer.scheduledTimer(
       withTimeInterval: Self.maxLoad, repeats: false
     ) { [weak self] _ in
-      self?.finishLoading(for: paneID)
+      // Timers fire on the main run loop, matching this class's isolation.
+      MainActor.assumeIsolated {
+        self?.finishLoading(for: paneID)
+      }
     }
   }
 
@@ -832,7 +836,10 @@ final class DFQuickTerminal {
     load.settleTimer = Timer.scheduledTimer(
       withTimeInterval: Self.settleQuiet, repeats: false
     ) { [weak self] _ in
-      self?.finishLoading(for: paneID)
+      // Timers fire on the main run loop, matching this class's isolation.
+      MainActor.assumeIsolated {
+        self?.finishLoading(for: paneID)
+      }
     }
   }
 

--- a/Sources/DraftFrameKit/DFQuickTerminal.swift
+++ b/Sources/DraftFrameKit/DFQuickTerminal.swift
@@ -81,8 +81,8 @@ final class DFQuickTerminal {
       object: nil)
     NotificationCenter.default.addObserver(
       self,
-      selector: #selector(sessionsDidChange),
-      name: .sessionsDidChange,
+      selector: #selector(sessionListChanged),
+      name: .sessionListDidChange,
       object: nil)
   }
 
@@ -708,7 +708,7 @@ final class DFQuickTerminal {
     focusInstalledContent()
   }
 
-  @objc private func sessionsDidChange() {
+  @objc private func sessionListChanged() {
     // Drop cached state for sessions that no longer exist, killing their
     // shells so closed sessions don't leak background processes.
     let liveIDs = Set(SessionManager.shared.sessions.map(\.id))

--- a/Sources/DraftFrameKit/DFSessionBar.swift
+++ b/Sources/DraftFrameKit/DFSessionBar.swift
@@ -18,9 +18,12 @@ final class DFSessionBar: NSView {
     buildUI()
     registerForDraggedTypes([.dfSessionDrag])
 
+    // Structural changes (membership, order, active card, PR pills) rebuild
+    // the cards; state and usage ticks update the existing cards in place so
+    // a working agent doesn't tear the bar down once a second.
     NotificationCenter.default.addObserver(
       self, selector: #selector(sessionsChanged),
-      name: .sessionsDidChange, object: nil
+      name: .sessionListDidChange, object: nil
     )
     NotificationCenter.default.addObserver(
       self, selector: #selector(sessionsChanged),
@@ -29,6 +32,14 @@ final class DFSessionBar: NSView {
     NotificationCenter.default.addObserver(
       self, selector: #selector(sessionsChanged),
       name: .prStatusDidChange, object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(sessionDynamicsChanged),
+      name: .sessionStateDidChange, object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(sessionDynamicsChanged),
+      name: .sessionUsageDidChange, object: nil
     )
   }
 
@@ -41,6 +52,17 @@ final class DFSessionBar: NSView {
 
   @objc private func sessionsChanged() {
     refreshCards()
+  }
+
+  /// State/usage tick: refresh every card in place. Falls back to a full
+  /// rebuild when a card reports a structural change (its context row
+  /// appearing for the first time).
+  @objc private func sessionDynamicsChanged() {
+    var needsRebuild = false
+    for case let card as SessionCard in cardStack.arrangedSubviews {
+      if !card.refreshDynamic() { needsRebuild = true }
+    }
+    if needsRebuild { refreshCards() }
   }
 
   private func buildUI() {
@@ -193,7 +215,7 @@ final class DFSessionBar: NSView {
   // MARK: - Card context-menu actions
 
   // Card menu items target the bar, not the card: cards are torn down and
-  // rebuilt on every `.sessionsDidChange` tick (~1.5s while an agent works),
+  // rebuilt whenever the session list or PR status changes,
   // and NSMenuItem holds its target weakly — targeting the card meant any
   // rebuild while the menu or a confirmation sheet was open silently dropped
   // the action (issue #13). The bar lives as long as the window, and each
@@ -284,7 +306,7 @@ final class DFSessionBar: NSView {
       let newName = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !newName.isEmpty else { return }
       session.name = newName
-      NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+      SessionEvents.postListChanged()
     }
   }
 }
@@ -314,6 +336,15 @@ final class SessionCard: NSView {
   private var prPill: NSTextField?
   private var prURL: URL?
 
+  // Views `refreshDynamic()` updates in place. Everything else on the card
+  // is fixed for its lifetime; structural changes rebuild the card instead.
+  private var accentBar: CALayer?
+  private var dot: NSView!
+  private var statusLabel: NSTextField!
+  private var modelLabel: NSTextField!
+  private var costLabel: NSTextField!
+  private var contextLabel: NSTextField?
+
   init(session: Session, isActive: Bool, index: Int, bar: DFSessionBar?) {
     self.session = session
     self.index = index
@@ -325,56 +356,29 @@ final class SessionCard: NSView {
     layer?.backgroundColor = Theme.surface2.cgColor
     layer?.cornerRadius = 8
 
-    // Card background carries a dimmed wash of the status color so a
-    // glance at the session bar shows what every session is doing.
-    let stateColor = session.state.color
-
+    // Structural chrome fixed for the card's lifetime; all status-driven
+    // styling (wash, border color, glow, dot) is applied by
+    // `applyStateStyling()`, shared with the in-place refresh path.
     if isActive {
-      // Bright background + status-coloured border and left bar so the
-      // active card visually telegraphs what claude is currently doing.
-      layer?.backgroundColor =
-        (Theme.surface3.blended(withFraction: 0.16, of: stateColor) ?? Theme.surface3).cgColor
-      layer?.borderColor = stateColor.cgColor
+      // Status-coloured border and left bar so the active card visually
+      // telegraphs what claude is currently doing.
       layer?.borderWidth = 1.5
 
       let accentBar = CALayer()
-      accentBar.backgroundColor = stateColor.cgColor
       accentBar.frame = CGRect(x: 0, y: 0, width: 4, height: bounds.height)
       accentBar.autoresizingMask = [.layerHeightSizable]
       accentBar.cornerRadius = 0
       layer?.masksToBounds = true
       layer?.addSublayer(accentBar)
+      self.accentBar = accentBar
     } else {
       // Dimmed inactive card, still tinted by its status color
-      layer?.backgroundColor =
-        (Theme.surface1.blended(withFraction: 0.12, of: stateColor) ?? Theme.surface1).cgColor
       layer?.borderWidth = 0
       alphaValue = 0.6
     }
 
-    // Pulsing border glow for attention/input states
-    let needsPulse = session.state == .needsAttention || session.state == .userInput
-    if needsPulse {
-      let glow = CALayer()
-      glow.cornerRadius = 8
-      glow.borderWidth = 1.5
-      glow.borderColor = session.state.color.cgColor
-      glow.frame = bounds
-      glow.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-      layer?.addSublayer(glow)
-      glowLayer = glow
-
-      let pulse = CABasicAnimation(keyPath: "opacity")
-      pulse.fromValue = 0.3
-      pulse.toValue = 1.0
-      pulse.duration = 1.4
-      pulse.autoreverses = true
-      pulse.repeatCount = .infinity
-      pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-      glow.add(pulse, forKey: "borderPulse")
-    }
-
     buildCard()
+    applyStateStyling()
 
     // Click to switch
     let click = NSClickGestureRecognizer(target: self, action: #selector(clicked(_:)))
@@ -476,46 +480,26 @@ final class SessionCard: NSView {
     nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     nameLabel.translatesAutoresizingMaskIntoConstraints = false
 
-    // Status dot + label
-    let dot = NSView()
+    // Status dot + label. Color, pulse, and shadow come from
+    // `applyStateStyling()`.
+    dot = NSView()
     dot.wantsLayer = true
-    dot.layer?.backgroundColor = session.state.color.cgColor
     dot.layer?.cornerRadius = 3.5
     dot.translatesAutoresizingMaskIntoConstraints = false
 
-    // Breathing pulse on the dot for attention/input states
-    if session.state == .needsAttention || session.state == .userInput {
-      let dotPulse = CABasicAnimation(keyPath: "opacity")
-      dotPulse.fromValue = 0.35
-      dotPulse.toValue = 1.0
-      dotPulse.duration = 1.4
-      dotPulse.autoreverses = true
-      dotPulse.repeatCount = .infinity
-      dotPulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-      dot.layer?.add(dotPulse, forKey: "dotPulse")
-
-      // Soft glow shadow behind the dot
-      dot.layer?.shadowColor = session.state.color.cgColor
-      dot.layer?.shadowOffset = .zero
-      dot.layer?.shadowRadius = 6
-      dot.layer?.shadowOpacity = 0.8
-      dot.layer?.masksToBounds = false
-    }
-
-    let statusLabel = NSTextField(labelWithString: session.state.label)
+    statusLabel = NSTextField(labelWithString: session.state.label)
     statusLabel.font = Theme.mono(9, weight: .medium)
-    statusLabel.textColor = session.state.color
     statusLabel.translatesAutoresizingMaskIntoConstraints = false
 
     // Model
-    let modelLabel = NSTextField(labelWithString: session.model)
+    modelLabel = NSTextField(labelWithString: session.model)
     modelLabel.font = Theme.mono(9)
     modelLabel.textColor = Theme.text3
     modelLabel.translatesAutoresizingMaskIntoConstraints = false
 
     // Cost. The label shows the current run (matches Claude Code's /usage);
     // the tooltip also reveals this tab's lifetime spend across all runs.
-    let costLabel = NSTextField(labelWithString: String(format: "$%.2f", session.cost))
+    costLabel = NSTextField(labelWithString: String(format: "$%.2f", session.cost))
     costLabel.font = Theme.mono(11)
     costLabel.textColor = Theme.text2
     costLabel.toolTip = String(
@@ -525,7 +509,7 @@ final class SessionCard: NSView {
 
     // Context window usage (e.g. "42.1K / 200K"). Hidden until the JSONL
     // watcher has parsed at least one assistant turn.
-    let contextLabel: NSTextField? = {
+    contextLabel = {
       guard session.contextTokens > 0 else { return nil }
       let label = NSTextField(
         labelWithString:
@@ -603,6 +587,97 @@ final class SessionCard: NSView {
       ])
     }
     NSLayoutConstraint.activate(constraints)
+  }
+
+  /// Re-apply everything the session's mutable state drives (colors, pulses,
+  /// labels) to the existing views, without tearing the card down — that
+  /// preserves hover, open menus, and in-flight drags across the once-a-second
+  /// ticks of a working agent. Returns false when the change is structural
+  /// (the context row appears once contextTokens > 0) and the bar must
+  /// rebuild the card instead.
+  func refreshDynamic() -> Bool {
+    guard (session.contextTokens > 0) == (contextLabel != nil) else { return false }
+    applyStateStyling()
+    statusLabel.stringValue = session.state.label
+    modelLabel.stringValue = session.model
+    costLabel.stringValue = String(format: "$%.2f", session.cost)
+    costLabel.toolTip = String(
+      format: "This run: $%.2f (matches /usage)\nThis tab, all runs: $%.2f",
+      session.cost, session.lifetimeCost)
+    contextLabel?.stringValue =
+      "\(TokenFormat.short(session.contextTokens)) / \(TokenFormat.short(session.maxContextTokens))"
+    return true
+  }
+
+  /// Status-driven styling shared by init and `refreshDynamic()`: the card
+  /// wash, border/accent color, pulsing glow, status dot, and status label
+  /// color. The card background carries a dimmed wash of the status color so
+  /// a glance at the session bar shows what every session is doing.
+  private func applyStateStyling() {
+    let stateColor = session.state.color
+
+    if isActive {
+      // Bright background + status-coloured border and left bar so the
+      // active card visually telegraphs what claude is currently doing.
+      layer?.backgroundColor =
+        (Theme.surface3.blended(withFraction: 0.16, of: stateColor) ?? Theme.surface3).cgColor
+      layer?.borderColor = stateColor.cgColor
+      accentBar?.backgroundColor = stateColor.cgColor
+    } else {
+      // Dimmed inactive card, still tinted by its status color
+      layer?.backgroundColor =
+        (Theme.surface1.blended(withFraction: 0.12, of: stateColor) ?? Theme.surface1).cgColor
+    }
+
+    // Pulsing border glow for attention/input states
+    glowLayer?.removeFromSuperlayer()
+    glowLayer = nil
+    let needsPulse = session.state == .needsAttention || session.state == .userInput
+    if needsPulse {
+      let glow = CALayer()
+      glow.cornerRadius = 8
+      glow.borderWidth = 1.5
+      glow.borderColor = stateColor.cgColor
+      glow.frame = bounds
+      glow.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+      layer?.addSublayer(glow)
+      glowLayer = glow
+
+      let pulse = CABasicAnimation(keyPath: "opacity")
+      pulse.fromValue = 0.3
+      pulse.toValue = 1.0
+      pulse.duration = 1.4
+      pulse.autoreverses = true
+      pulse.repeatCount = .infinity
+      pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+      glow.add(pulse, forKey: "borderPulse")
+    }
+
+    // Status dot color plus breathing pulse and glow shadow while attention
+    // or input is wanted.
+    dot.layer?.backgroundColor = stateColor.cgColor
+    dot.layer?.removeAnimation(forKey: "dotPulse")
+    if needsPulse {
+      let dotPulse = CABasicAnimation(keyPath: "opacity")
+      dotPulse.fromValue = 0.35
+      dotPulse.toValue = 1.0
+      dotPulse.duration = 1.4
+      dotPulse.autoreverses = true
+      dotPulse.repeatCount = .infinity
+      dotPulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+      dot.layer?.add(dotPulse, forKey: "dotPulse")
+
+      // Soft glow shadow behind the dot
+      dot.layer?.shadowColor = stateColor.cgColor
+      dot.layer?.shadowOffset = .zero
+      dot.layer?.shadowRadius = 6
+      dot.layer?.shadowOpacity = 0.8
+      dot.layer?.masksToBounds = false
+    } else {
+      dot.layer?.shadowOpacity = 0
+    }
+
+    statusLabel.textColor = stateColor
   }
 
   private func makePRPill(status: PRStatus) -> NSTextField {

--- a/Sources/DraftFrameKit/DFSettingsWindow.swift
+++ b/Sources/DraftFrameKit/DFSettingsWindow.swift
@@ -4,6 +4,7 @@ import AppKit
 /// toggles (persisted across launches) and the PR automation config applied
 /// to worktrees the user hasn't configured individually in the sidebar.
 /// Singleton — reuses the same window across show/hide cycles.
+@MainActor
 final class DFSettingsWindow: NSObject, NSWindowDelegate {
   static let shared = DFSettingsWindow()
 

--- a/Sources/DraftFrameKit/DFShortcutsWindow.swift
+++ b/Sources/DraftFrameKit/DFShortcutsWindow.swift
@@ -2,6 +2,7 @@ import AppKit
 
 /// Help window listing all keyboard shortcuts.
 /// Singleton — reuses the same window across show/hide cycles.
+@MainActor
 final class DFShortcutsWindow: NSObject, NSWindowDelegate {
   static let shared = DFShortcutsWindow()
 

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -66,28 +66,31 @@ final class DFSidebar: NSView {
   private var worktreeRefreshQueued = false
 
   /// Slow poll catching worktree changes made outside the app.
-  private var externalWorktreeTimer: Timer?
+  /// `nonisolated(unsafe)` so the (never-raced) invalidate in deinit
+  /// compiles; every other access is on the main actor.
+  private nonisolated(unsafe) var externalWorktreeTimer: Timer?
 
-  /// Comparable snapshot of everything that affects the rendered worktree
-  /// rows. Refreshes arrive from list/active-session events, direct calls,
-  /// and the external-changes poll regardless of whether anything rendered
-  /// actually changed; we use this to skip the rebuild in those no-op cases.
-  /// Excludes `isExpanded` so collapse/expand can animate without rebuilding
-  /// rows.
-  private struct WorktreesContentSnapshot: Equatable {
-    let projectPaths: [String]
-    let activeDir: String?
-    let pendingRemovals: Set<String>
-    let pullsInFlight: Set<String>
-    let worktreeSetupsInFlight: Set<String>
-    let worktreesPerProject: [String: [WorktreeKey]]
+  /// Everything that affects ONE project's rendered section (header row +
+  /// worktree rows). Sections are compared individually so a change confined
+  /// to one project (a spinner appearing, a worktree created) rebuilds only
+  /// that project's rows — a full-stack rebuild visibly flashes the whole
+  /// list. Excludes `isExpanded` so collapse/expand can animate without
+  /// rebuilding rows.
+  private struct ProjectSectionKey: Equatable {
+    let path: String
+    let name: String
+    let isActive: Bool
+    let isPulling: Bool
+    let isSettingUp: Bool
+    let worktrees: [WorktreeKey]
   }
   private struct WorktreeKey: Equatable {
     let path: String
     let branch: String
     let isBare: Bool
   }
-  private var lastContentSnapshot: WorktreesContentSnapshot?
+  /// Section keys as last rendered, in stack order.
+  private var lastSectionKeys: [ProjectSectionKey] = []
 
   /// Comparable snapshot of the rendered CHANGES rows. `refreshFiles()` is
   /// driven by FSEvents and session state changes, which repeat while an
@@ -118,8 +121,10 @@ final class DFSidebar: NSView {
   private var watchedFilesDir: String?
 
   /// Per-project view references so collapse/expand can animate `isHidden`
-  /// on existing rows instead of tearing the stack down and rebuilding.
+  /// on existing rows instead of tearing the stack down and rebuilding, and
+  /// so `rebuildSection` can splice one project's views in place.
   private var projectChevronViews: [String: NSImageView] = [:]
+  private var projectHeaderRows: [String: NSView] = [:]
   private var projectWorktreeRows: [String: [NSView]] = [:]
   private var lastExpansionStates: [String: Bool] = [:]
 
@@ -145,7 +150,10 @@ final class DFSidebar: NSView {
     externalWorktreeTimer = Timer.scheduledTimer(
       withTimeInterval: 10.0, repeats: true
     ) { [weak self] _ in
-      self?.refreshWorktrees()
+      // Scheduled on the main run loop, matching the view's isolation.
+      MainActor.assumeIsolated {
+        self?.refreshWorktrees()
+      }
     }
     NotificationCenter.default.addObserver(
       self, selector: #selector(refreshWatchdogs),
@@ -462,11 +470,15 @@ final class DFSidebar: NSView {
       for path in projectPaths {
         worktreesPerProject[path] = Self.enumerateWorktrees(for: path)
       }
+      // Immutable bindings so the main-queue hop captures lets, not the
+      // enclosing closure's vars (a Swift 6 sendability error).
+      let enumerated = worktreesPerProject
+      let sidebar = self
       DispatchQueue.main.async {
-        guard let self = self else { return }
+        guard let self = sidebar else { return }
         self.worktreeRefreshInFlight = false
-        self.lastEnumerated = worktreesPerProject
-        self.applyWorktreeResults(worktreesPerProject)
+        self.lastEnumerated = enumerated
+        self.applyWorktreeResults(enumerated)
         if self.worktreeRefreshQueued {
           self.worktreeRefreshQueued = false
           self.refreshWorktrees()
@@ -499,21 +511,22 @@ final class DFSidebar: NSView {
         .filter { !pendingRemovals.contains($0.path) }
     }
 
-    let snapshot = WorktreesContentSnapshot(
-      projectPaths: projects.map { $0.path },
-      activeDir: activeDir,
-      pendingRemovals: pendingRemovals,
-      pullsInFlight: pullsInFlight,
-      worktreeSetupsInFlight: worktreeSetupsInFlight,
-      worktreesPerProject: worktreesPerProject.mapValues { wts in
-        wts.map { WorktreeKey(path: $0.path, branch: $0.branch, isBare: $0.isBare) }
-      }
-    )
+    let sections = projects.map { project in
+      ProjectSectionKey(
+        path: project.path,
+        name: project.name,
+        isActive: project.path == activeDir,
+        isPulling: pullsInFlight.contains(project.path),
+        isSettingUp: worktreeSetupsInFlight.contains(project.path),
+        worktrees: (worktreesPerProject[project.path] ?? []).map {
+          WorktreeKey(path: $0.path, branch: $0.branch, isBare: $0.isBare)
+        })
+    }
     let expansionStates = projects.reduce(into: [String: Bool]()) {
       $0[$1.path] = $1.isExpanded
     }
 
-    let contentChanged = (snapshot != lastContentSnapshot)
+    let contentChanged = (sections != lastSectionKeys)
     let expansionChanged = (expansionStates != lastExpansionStates)
     if !contentChanged && !expansionChanged {
       // The external-changes poll and no-op event bursts land here — nothing
@@ -522,11 +535,25 @@ final class DFSidebar: NSView {
     }
 
     if contentChanged {
-      rebuildWorktreeRows(
-        projects: projects,
-        activeDir: activeDir,
-        worktreesPerProject: worktreesPerProject)
-      lastContentSnapshot = snapshot
+      if sections.map(\.path) == lastSectionKeys.map(\.path), !sections.isEmpty {
+        // Membership and order unchanged — replace only the sections whose
+        // content differs, leaving every other project's rows untouched.
+        // Worktree creation flows through here three times (spinner on,
+        // spinner off + new row, session highlight); confining each pass to
+        // the one affected project keeps the rest of the list from flashing.
+        for (idx, section) in sections.enumerated() where section != lastSectionKeys[idx] {
+          rebuildSection(
+            project: projects[idx],
+            activeDir: activeDir,
+            worktrees: worktreesPerProject[section.path] ?? [])
+        }
+      } else {
+        rebuildWorktreeRows(
+          projects: projects,
+          activeDir: activeDir,
+          worktreesPerProject: worktreesPerProject)
+      }
+      lastSectionKeys = sections
       // Rows are freshly created; apply expansion state synchronously so
       // collapsed projects don't briefly flash their worktrees.
       applyExpansionStates(expansionStates, animated: false)
@@ -534,6 +561,28 @@ final class DFSidebar: NSView {
       applyExpansionStates(expansionStates, animated: !lastExpansionStates.isEmpty)
     }
     lastExpansionStates = expansionStates
+  }
+
+  /// Replace one project's header + worktree rows in place at their current
+  /// stack position. Callers guarantee the project already has a section
+  /// (same path set as the last render).
+  private func rebuildSection(
+    project: ProjectManager.Project,
+    activeDir: String?,
+    worktrees: [WorktreeManager.Worktree]
+  ) {
+    guard let oldHeader = projectHeaderRows[project.path],
+      let insertAt = worktreeStack.arrangedSubviews.firstIndex(of: oldHeader)
+    else { return }
+    for view in [oldHeader] + (projectWorktreeRows[project.path] ?? []) {
+      worktreeStack.removeArrangedSubview(view)
+      view.removeFromSuperview()
+    }
+    let views = buildProjectSection(
+      project: project, activeDir: activeDir, worktrees: worktrees)
+    for (offset, view) in views.enumerated() {
+      worktreeStack.insertArrangedSubview(view, at: insertAt + offset)
+    }
   }
 
   private func rebuildWorktreeRows(
@@ -546,6 +595,7 @@ final class DFSidebar: NSView {
       v.removeFromSuperview()
     }
     projectChevronViews.removeAll(keepingCapacity: true)
+    projectHeaderRows.removeAll(keepingCapacity: true)
     projectWorktreeRows.removeAll(keepingCapacity: true)
 
     if projects.isEmpty {
@@ -556,216 +606,236 @@ final class DFSidebar: NSView {
     }
 
     for project in projects {
-      let isActive = project.path == activeDir
-
-      // Project header row — clickable to expand/collapse. Chevron icon is
-      // set by applyExpansionStates so we don't need to rebuild on toggle.
-      let projectRow = makeClickableRow(
-        icon: "chevron.right", text: project.name,
-        detail: nil,
-        target: self, action: #selector(projectRowClicked(_:)))
-      projectRow.worktreePath = project.path
-      projectRow.heightAnchor.constraint(equalToConstant: 28).isActive = true
-
-      if isActive, let lbl = projectRow.subviews.compactMap({ $0 as? NSTextField }).first {
-        lbl.font = Theme.mono(12, weight: .medium)
-        lbl.textColor = Theme.text1
+      let views = buildProjectSection(
+        project: project,
+        activeDir: activeDir,
+        worktrees: worktreesPerProject[project.path] ?? [])
+      for view in views {
+        worktreeStack.addArrangedSubview(view)
       }
-
-      if let chevron = projectRow.subviews.compactMap({ $0 as? NSImageView }).first {
-        projectChevronViews[project.path] = chevron
-      }
-
-      let addBtn = NSButton(title: "", target: self, action: #selector(addWorktreeForProject(_:)))
-      addBtn.image = Self.leafPlusBadge
-      addBtn.isBordered = false
-      addBtn.imageScaling = .scaleProportionallyDown
-      addBtn.contentTintColor = Theme.text3
-      addBtn.toolTip = "New worktree in \(project.name)"
-      addBtn.translatesAutoresizingMaskIntoConstraints = false
-      projectRow.addSubview(addBtn)
-      NSLayoutConstraint.activate([
-        addBtn.trailingAnchor.constraint(equalTo: projectRow.trailingAnchor),
-        addBtn.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
-        addBtn.widthAnchor.constraint(equalToConstant: 16),
-        addBtn.heightAnchor.constraint(equalToConstant: 16),
-      ])
-
-      // While a background default-branch pull or a worktree setup
-      // (base-branch pull + create) runs for this project, show a spinner
-      // next to the add button. Both sets are part of the snapshot, so the
-      // row rebuilds when either changes.
-      let isPulling = pullsInFlight.contains(project.path)
-      var trailingControl: NSView = addBtn
-      if isPulling || worktreeSetupsInFlight.contains(project.path) {
-        let spinner = NSProgressIndicator()
-        spinner.style = .spinning
-        spinner.controlSize = .small
-        spinner.isIndeterminate = true
-        spinner.isDisplayedWhenStopped = false
-        spinner.startAnimation(nil)
-        spinner.translatesAutoresizingMaskIntoConstraints = false
-        projectRow.addSubview(spinner)
-        NSLayoutConstraint.activate([
-          spinner.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
-          spinner.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
-          spinner.widthAnchor.constraint(equalToConstant: 16),
-          spinner.heightAnchor.constraint(equalToConstant: 16),
-        ])
-        trailingControl = spinner
-      }
-
-      // The row label has no trailing constraint of its own; in a narrow
-      // sidebar a long project name would run underneath the buttons. Pin it
-      // clear of them and truncate the name instead.
-      if let lbl = projectRow.subviews.compactMap({ $0 as? NSTextField }).first {
-        lbl.lineBreakMode = .byTruncatingTail
-        lbl.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        lbl.trailingAnchor.constraint(
-          lessThanOrEqualTo: trailingControl.leadingAnchor, constant: -6
-        ).isActive = true
-      }
-
-      let menu = NSMenu()
-
-      // Pull the default branch from its remote — keeps new worktrees (which
-      // branch off the local default branch) from starting stale. Skipped
-      // when no default branch is resolvable (e.g. not a git repo).
-      if let defaultBranch = WorktreeManager.shared.defaultBranch(repoRoot: project.path) {
-        // A nil action leaves the item disabled while a pull is in flight.
-        let pullItem = NSMenuItem(
-          title: isPulling ? "Pulling \(defaultBranch)…" : "Pull \(defaultBranch)",
-          action: isPulling ? nil : #selector(pullDefaultBranch(_:)),
-          keyEquivalent: "")
-        pullItem.target = self
-        pullItem.representedObject = DefaultBranchPullRequest(
-          repoRoot: project.path, branch: defaultBranch)
-        menu.addItem(pullItem)
-      }
-
-      let switchItem = NSMenuItem(
-        title: "Switch to Project", action: #selector(switchToProject(_:)), keyEquivalent: "")
-      switchItem.target = self
-      switchItem.representedObject = project.path
-      menu.addItem(switchItem)
-
-      let showItem = NSMenuItem(
-        title: "Show in Finder", action: #selector(showWorktreeInFinder(_:)), keyEquivalent: "")
-      showItem.target = self
-      showItem.representedObject = project.path
-      menu.addItem(showItem)
-
-      let fromBranchItem = NSMenuItem(
-        title: "New Worktree from Branch", action: #selector(addWorktreeFromBranch(_:)),
-        keyEquivalent: "")
-      fromBranchItem.target = self
-      fromBranchItem.representedObject = project.path
-      menu.addItem(fromBranchItem)
-
-      menu.addItem(NSMenuItem.separator())
-      let removeItem = NSMenuItem(
-        title: "Remove from List", action: #selector(removeProjectFromList(_:)), keyEquivalent: "")
-      removeItem.target = self
-      removeItem.representedObject = project.path
-      menu.addItem(removeItem)
-
-      projectRow.menu = menu
-      worktreeStack.addArrangedSubview(projectRow)
-
-      // Build worktree rows for every project regardless of expansion. They
-      // start hidden; applyExpansionStates flips isHidden to reveal them.
-      let worktrees = worktreesPerProject[project.path] ?? []
-      var wtRows: [NSView] = []
-      if worktrees.isEmpty {
-        let mainRow = makeRow(icon: "arrow.triangle.branch", text: "  main", detail: "base")
-        mainRow.heightAnchor.constraint(equalToConstant: 26).isActive = true
-        worktreeStack.addArrangedSubview(mainRow)
-        wtRows.append(mainRow)
-      } else {
-        for wt in worktrees {
-          let branchName = wt.branch.isEmpty ? "detached" : wt.branch
-          let isBase = wt.isBare
-          // The primary worktree is the project root itself (not a child
-          // under .claude/worktrees/). Compare symlink-resolved paths: git
-          // reports realpaths (e.g. /private/var) while the project may have
-          // been added under an unresolved spelling.
-          let resolvedProjectPath =
-            URL(fileURLWithPath: project.path).resolvingSymlinksInPath().path
-          let isPrimary =
-            !isBase
-            && URL(fileURLWithPath: wt.path).resolvingSymlinksInPath().path == resolvedProjectPath
-          let icon = isPrimary ? "circle.fill" : "arrow.triangle.branch"
-          let detail = isBase ? "base" : nil
-          let row = makeClickableRow(
-            icon: icon, text: "  \(branchName)",
-            detail: detail,
-            target: self, action: #selector(worktreeRowClicked(_:)))
-          if isPrimary {
-            row.toolTip = "Currently checked-out branch in \(project.name)"
-            if let img = row.subviews.compactMap({ $0 as? NSImageView }).first {
-              let config = NSImage.SymbolConfiguration(pointSize: 6, weight: .regular)
-              img.image = img.image?.withSymbolConfiguration(config)
-            }
-          }
-          row.worktreeName = branchName
-          row.worktreePath = wt.path
-          row.isBaseWorktree = isBase
-
-          let wtMenu = NSMenu()
-          let openItem = NSMenuItem(
-            title: "Open Session Here", action: #selector(openSessionFromMenu(_:)),
-            keyEquivalent: "")
-          openItem.target = self
-          openItem.representedObject = wt
-          wtMenu.addItem(openItem)
-          let branchItem = NSMenuItem(
-            title: "New Worktree from Here", action: #selector(addWorktreeFromWorktree(_:)),
-            keyEquivalent: "")
-          branchItem.target = self
-          // Carry the source worktree alongside the project's repo root so the
-          // action can base the new worktree's branch off this worktree.
-          branchItem.representedObject = WorktreeBranchRequest(source: wt, repoRoot: project.path)
-          wtMenu.addItem(branchItem)
-          if !isBase {
-            wtMenu.addItem(NSMenuItem.separator())
-            // Rename only applies to draftframe-managed worktrees — the
-            // primary checkout is the project root itself and can't be moved
-            // under .claude/worktrees/, and renaming a hand-made worktree
-            // would relocate it there out from under the user.
-            if !isPrimary && WorktreeManager.isManagedWorktree(wt.path) {
-              let renameItem = NSMenuItem(
-                title: "Rename Worktree", action: #selector(renameWorktreeFromMenu(_:)),
-                keyEquivalent: "")
-              renameItem.target = self
-              renameItem.representedObject = WorktreeRenameRequest(
-                worktree: wt, repoRoot: project.path)
-              wtMenu.addItem(renameItem)
-            }
-            let rmItem = NSMenuItem(
-              title: "Remove Worktree", action: #selector(removeWorktreeFromMenu(_:)),
-              keyEquivalent: "")
-            rmItem.target = self
-            // Carry the project's repo root alongside the worktree so the
-            // remove action can invoke git against the right repo (not
-            // DraftFrame's own repo via the singleton).
-            rmItem.representedObject = WorktreeRemovalRequest(worktree: wt, repoRoot: project.path)
-            wtMenu.addItem(rmItem)
-          }
-          wtMenu.addItem(NSMenuItem.separator())
-          let copyItem = NSMenuItem(
-            title: "Copy Path", action: #selector(copyWorktreePath(_:)), keyEquivalent: "")
-          copyItem.target = self
-          copyItem.representedObject = wt.path
-          wtMenu.addItem(copyItem)
-          row.menu = wtMenu
-
-          row.heightAnchor.constraint(equalToConstant: 26).isActive = true
-          worktreeStack.addArrangedSubview(row)
-          wtRows.append(row)
-        }
-      }
-      projectWorktreeRows[project.path] = wtRows
     }
+  }
+
+  /// Build one project's views — header row followed by its worktree rows —
+  /// registering them in the per-project reference maps. The caller decides
+  /// where the views land (appended on a full rebuild, spliced in place by
+  /// `rebuildSection`).
+  private func buildProjectSection(
+    project: ProjectManager.Project,
+    activeDir: String?,
+    worktrees: [WorktreeManager.Worktree]
+  ) -> [NSView] {
+    var views: [NSView] = []
+    let isActive = project.path == activeDir
+
+    // Project header row — clickable to expand/collapse. Chevron icon is
+    // set by applyExpansionStates so we don't need to rebuild on toggle.
+    let projectRow = makeClickableRow(
+      icon: "chevron.right", text: project.name,
+      detail: nil,
+      target: self, action: #selector(projectRowClicked(_:)))
+    projectRow.worktreePath = project.path
+    projectRow.heightAnchor.constraint(equalToConstant: 28).isActive = true
+
+    if isActive, let lbl = projectRow.subviews.compactMap({ $0 as? NSTextField }).first {
+      lbl.font = Theme.mono(12, weight: .medium)
+      lbl.textColor = Theme.text1
+    }
+
+    if let chevron = projectRow.subviews.compactMap({ $0 as? NSImageView }).first {
+      projectChevronViews[project.path] = chevron
+    }
+
+    let addBtn = NSButton(title: "", target: self, action: #selector(addWorktreeForProject(_:)))
+    addBtn.image = Self.leafPlusBadge
+    addBtn.isBordered = false
+    addBtn.imageScaling = .scaleProportionallyDown
+    addBtn.contentTintColor = Theme.text3
+    addBtn.toolTip = "New worktree in \(project.name)"
+    addBtn.translatesAutoresizingMaskIntoConstraints = false
+    projectRow.addSubview(addBtn)
+    NSLayoutConstraint.activate([
+      addBtn.trailingAnchor.constraint(equalTo: projectRow.trailingAnchor),
+      addBtn.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
+      addBtn.widthAnchor.constraint(equalToConstant: 16),
+      addBtn.heightAnchor.constraint(equalToConstant: 16),
+    ])
+
+    // While a background default-branch pull or a worktree setup
+    // (base-branch pull + create) runs for this project, show a spinner
+    // next to the add button. Both sets are part of the snapshot, so the
+    // row rebuilds when either changes.
+    let isPulling = pullsInFlight.contains(project.path)
+    var trailingControl: NSView = addBtn
+    if isPulling || worktreeSetupsInFlight.contains(project.path) {
+      let spinner = NSProgressIndicator()
+      spinner.style = .spinning
+      spinner.controlSize = .small
+      spinner.isIndeterminate = true
+      spinner.isDisplayedWhenStopped = false
+      spinner.startAnimation(nil)
+      spinner.translatesAutoresizingMaskIntoConstraints = false
+      projectRow.addSubview(spinner)
+      NSLayoutConstraint.activate([
+        spinner.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
+        spinner.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
+        spinner.widthAnchor.constraint(equalToConstant: 16),
+        spinner.heightAnchor.constraint(equalToConstant: 16),
+      ])
+      trailingControl = spinner
+    }
+
+    // The row label has no trailing constraint of its own; in a narrow
+    // sidebar a long project name would run underneath the buttons. Pin it
+    // clear of them and truncate the name instead.
+    if let lbl = projectRow.subviews.compactMap({ $0 as? NSTextField }).first {
+      lbl.lineBreakMode = .byTruncatingTail
+      lbl.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+      lbl.trailingAnchor.constraint(
+        lessThanOrEqualTo: trailingControl.leadingAnchor, constant: -6
+      ).isActive = true
+    }
+
+    let menu = NSMenu()
+
+    // Pull the default branch from its remote — keeps new worktrees (which
+    // branch off the local default branch) from starting stale. Skipped
+    // when no default branch is resolvable (e.g. not a git repo).
+    if let defaultBranch = WorktreeManager.shared.defaultBranch(repoRoot: project.path) {
+      // A nil action leaves the item disabled while a pull is in flight.
+      let pullItem = NSMenuItem(
+        title: isPulling ? "Pulling \(defaultBranch)…" : "Pull \(defaultBranch)",
+        action: isPulling ? nil : #selector(pullDefaultBranch(_:)),
+        keyEquivalent: "")
+      pullItem.target = self
+      pullItem.representedObject = DefaultBranchPullRequest(
+        repoRoot: project.path, branch: defaultBranch)
+      menu.addItem(pullItem)
+    }
+
+    let switchItem = NSMenuItem(
+      title: "Switch to Project", action: #selector(switchToProject(_:)), keyEquivalent: "")
+    switchItem.target = self
+    switchItem.representedObject = project.path
+    menu.addItem(switchItem)
+
+    let showItem = NSMenuItem(
+      title: "Show in Finder", action: #selector(showWorktreeInFinder(_:)), keyEquivalent: "")
+    showItem.target = self
+    showItem.representedObject = project.path
+    menu.addItem(showItem)
+
+    let fromBranchItem = NSMenuItem(
+      title: "New Worktree from Branch", action: #selector(addWorktreeFromBranch(_:)),
+      keyEquivalent: "")
+    fromBranchItem.target = self
+    fromBranchItem.representedObject = project.path
+    menu.addItem(fromBranchItem)
+
+    menu.addItem(NSMenuItem.separator())
+    let removeItem = NSMenuItem(
+      title: "Remove from List", action: #selector(removeProjectFromList(_:)), keyEquivalent: "")
+    removeItem.target = self
+    removeItem.representedObject = project.path
+    menu.addItem(removeItem)
+
+    projectRow.menu = menu
+    views.append(projectRow)
+    projectHeaderRows[project.path] = projectRow
+
+    // Build worktree rows for every project regardless of expansion. They
+    // start hidden; applyExpansionStates flips isHidden to reveal them.
+    var wtRows: [NSView] = []
+    if worktrees.isEmpty {
+      let mainRow = makeRow(icon: "arrow.triangle.branch", text: "  main", detail: "base")
+      mainRow.heightAnchor.constraint(equalToConstant: 26).isActive = true
+      views.append(mainRow)
+      wtRows.append(mainRow)
+    } else {
+      for wt in worktrees {
+        let branchName = wt.branch.isEmpty ? "detached" : wt.branch
+        let isBase = wt.isBare
+        // The primary worktree is the project root itself (not a child
+        // under .claude/worktrees/). Compare symlink-resolved paths: git
+        // reports realpaths (e.g. /private/var) while the project may have
+        // been added under an unresolved spelling.
+        let resolvedProjectPath =
+          URL(fileURLWithPath: project.path).resolvingSymlinksInPath().path
+        let isPrimary =
+          !isBase
+          && URL(fileURLWithPath: wt.path).resolvingSymlinksInPath().path == resolvedProjectPath
+        let icon = isPrimary ? "circle.fill" : "arrow.triangle.branch"
+        let detail = isBase ? "base" : nil
+        let row = makeClickableRow(
+          icon: icon, text: "  \(branchName)",
+          detail: detail,
+          target: self, action: #selector(worktreeRowClicked(_:)))
+        if isPrimary {
+          row.toolTip = "Currently checked-out branch in \(project.name)"
+          if let img = row.subviews.compactMap({ $0 as? NSImageView }).first {
+            let config = NSImage.SymbolConfiguration(pointSize: 6, weight: .regular)
+            img.image = img.image?.withSymbolConfiguration(config)
+          }
+        }
+        row.worktreeName = branchName
+        row.worktreePath = wt.path
+        row.isBaseWorktree = isBase
+
+        let wtMenu = NSMenu()
+        let openItem = NSMenuItem(
+          title: "Open Session Here", action: #selector(openSessionFromMenu(_:)),
+          keyEquivalent: "")
+        openItem.target = self
+        openItem.representedObject = wt
+        wtMenu.addItem(openItem)
+        let branchItem = NSMenuItem(
+          title: "New Worktree from Here", action: #selector(addWorktreeFromWorktree(_:)),
+          keyEquivalent: "")
+        branchItem.target = self
+        // Carry the source worktree alongside the project's repo root so the
+        // action can base the new worktree's branch off this worktree.
+        branchItem.representedObject = WorktreeBranchRequest(source: wt, repoRoot: project.path)
+        wtMenu.addItem(branchItem)
+        if !isBase {
+          wtMenu.addItem(NSMenuItem.separator())
+          // Rename only applies to draftframe-managed worktrees — the
+          // primary checkout is the project root itself and can't be moved
+          // under .claude/worktrees/, and renaming a hand-made worktree
+          // would relocate it there out from under the user.
+          if !isPrimary && WorktreeManager.isManagedWorktree(wt.path) {
+            let renameItem = NSMenuItem(
+              title: "Rename Worktree", action: #selector(renameWorktreeFromMenu(_:)),
+              keyEquivalent: "")
+            renameItem.target = self
+            renameItem.representedObject = WorktreeRenameRequest(
+              worktree: wt, repoRoot: project.path)
+            wtMenu.addItem(renameItem)
+          }
+          let rmItem = NSMenuItem(
+            title: "Remove Worktree", action: #selector(removeWorktreeFromMenu(_:)),
+            keyEquivalent: "")
+          rmItem.target = self
+          // Carry the project's repo root alongside the worktree so the
+          // remove action can invoke git against the right repo (not
+          // DraftFrame's own repo via the singleton).
+          rmItem.representedObject = WorktreeRemovalRequest(worktree: wt, repoRoot: project.path)
+          wtMenu.addItem(rmItem)
+        }
+        wtMenu.addItem(NSMenuItem.separator())
+        let copyItem = NSMenuItem(
+          title: "Copy Path", action: #selector(copyWorktreePath(_:)), keyEquivalent: "")
+        copyItem.target = self
+        copyItem.representedObject = wt.path
+        wtMenu.addItem(copyItem)
+        row.menu = wtMenu
+
+        row.heightAnchor.constraint(equalToConstant: 26).isActive = true
+        views.append(row)
+        wtRows.append(row)
+      }
+    }
+    projectWorktreeRows[project.path] = wtRows
+    return views
   }
 
   private func applyExpansionStates(_ states: [String: Bool], animated: Bool) {
@@ -1009,8 +1079,9 @@ final class DFSidebar: NSView {
     DispatchQueue.global(qos: .userInitiated).async { [weak self] in
       let error = WorktreeManager.shared.pullDefaultBranch(
         repoRoot: req.repoRoot, branch: req.branch)
+      let sidebar = self
       DispatchQueue.main.async {
-        guard let self = self else { return }
+        guard let self = sidebar else { return }
         self.pullsInFlight.remove(req.repoRoot)
         self.refreshWorktrees()
         if let error = error {
@@ -1198,8 +1269,9 @@ final class DFSidebar: NSView {
 
     gitStatusQueue.async { [weak self] in
       let changedFiles = worktreeDir.map { Self.gitChangedFiles(in: $0) } ?? []
+      let sidebar = self
       DispatchQueue.main.async {
-        guard let self = self else { return }
+        guard let self = sidebar else { return }
         self.filesRefreshInFlight = false
 
         // The active scope can change while git runs (session switch); the

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -60,16 +60,20 @@ final class DFSidebar: NSView {
 
   /// True while an enumeration pass is on `worktreeEnumQueue`. Further
   /// `refreshWorktrees()` calls set `worktreeRefreshQueued` so at most one
-  /// pass runs at a time and bursts of `.sessionsDidChange` pings collapse
+  /// pass runs at a time and bursts of refresh requests collapse
   /// into a single trailing re-check (same pattern as `filesRefreshInFlight`).
   private var worktreeRefreshInFlight = false
   private var worktreeRefreshQueued = false
 
+  /// Slow poll catching worktree changes made outside the app.
+  private var externalWorktreeTimer: Timer?
+
   /// Comparable snapshot of everything that affects the rendered worktree
-  /// rows. `.sessionsDidChange` fires every ~1.5s from JSONL/status pollers
-  /// regardless of whether projects, active dir, or worktrees actually
-  /// changed; we use this to skip the rebuild in those no-op cases. Excludes
-  /// `isExpanded` so collapse/expand can animate without rebuilding rows.
+  /// rows. Refreshes arrive from list/active-session events, direct calls,
+  /// and the external-changes poll regardless of whether anything rendered
+  /// actually changed; we use this to skip the rebuild in those no-op cases.
+  /// Excludes `isExpanded` so collapse/expand can animate without rebuilding
+  /// rows.
   private struct WorktreesContentSnapshot: Equatable {
     let projectPaths: [String]
     let activeDir: String?
@@ -86,9 +90,9 @@ final class DFSidebar: NSView {
   private var lastContentSnapshot: WorktreesContentSnapshot?
 
   /// Comparable snapshot of the rendered CHANGES rows. `refreshFiles()` is
-  /// driven by `.sessionsDidChange`, which fires repeatedly while an agent
-  /// works; we use this to rebuild the rows only when the actual changed-file
-  /// set differs, instead of tearing the stack down on every notification.
+  /// driven by FSEvents and session state changes, which repeat while an
+  /// agent works; we use this to rebuild the rows only when the actual
+  /// changed-file set differs, instead of tearing the stack down every time.
   private struct FilesContentSnapshot: Equatable {
     let worktreeDir: String?
     let files: [ChangedFile]
@@ -127,8 +131,22 @@ final class DFSidebar: NSView {
 
     NotificationCenter.default.addObserver(
       self, selector: #selector(refreshWorktrees),
-      name: .sessionsDidChange, object: nil
+      name: .sessionListDidChange, object: nil
     )
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(refreshWorktrees),
+      name: .activeSessionDidChange, object: nil
+    )
+    // Worktrees created or removed outside the app (a plain `git worktree
+    // add` in a terminal) have no in-app event; the old catch-all
+    // notification used to pick those up incidentally. A slow poll covers
+    // them: the enumeration runs off-main and the snapshot guard makes a
+    // no-change pass free.
+    externalWorktreeTimer = Timer.scheduledTimer(
+      withTimeInterval: 10.0, repeats: true
+    ) { [weak self] _ in
+      self?.refreshWorktrees()
+    }
     NotificationCenter.default.addObserver(
       self, selector: #selector(refreshWatchdogs),
       name: .watchdogsDidChange, object: nil
@@ -154,6 +172,7 @@ final class DFSidebar: NSView {
   required init?(coder: NSCoder) { fatalError() }
 
   deinit {
+    externalWorktreeTimer?.invalidate()
     NotificationCenter.default.removeObserver(self)
   }
 
@@ -351,12 +370,12 @@ final class DFSidebar: NSView {
       self, selector: #selector(activeSessionChanged),
       name: .activeSessionDidChange, object: nil
     )
-    // Belt-and-braces fallback: also refresh whenever an agent advances (and
-    // on the ~1.5s status polls), in case FSEvents misses a change or hasn't
-    // started yet. The snapshot guard in refreshFiles() keeps no-ops cheap.
+    // Belt-and-braces fallback: also refresh when an agent's state flips
+    // (start/finish of a turn is when files change), in case FSEvents misses
+    // a change or hasn't started yet. The snapshot guard keeps no-ops cheap.
     NotificationCenter.default.addObserver(
       self, selector: #selector(refreshFiles),
-      name: .sessionsDidChange, object: nil
+      name: .sessionStateDidChange, object: nil
     )
 
     // Auto-refresh toolkit when config file changes
@@ -497,7 +516,7 @@ final class DFSidebar: NSView {
     let contentChanged = (snapshot != lastContentSnapshot)
     let expansionChanged = (expansionStates != lastExpansionStates)
     if !contentChanged && !expansionChanged {
-      // Polling-driven .sessionsDidChange lands here ~40x/min — nothing
+      // The external-changes poll and no-op event bursts land here — nothing
       // visible has changed, so skip the rebuild and the resulting flash.
       return
     }
@@ -1204,9 +1223,9 @@ final class DFSidebar: NSView {
   }
 
   private func applyChangedFiles(_ changedFiles: [ChangedFile], worktreeDir: String?) {
-    // `.sessionsDidChange` lands here repeatedly while an agent works; skip the
-    // teardown/rebuild (and the hover/click disruption it causes) unless the
-    // changed-file set actually differs from what's already rendered.
+    // FSEvents and state changes land here repeatedly while an agent works;
+    // skip the teardown/rebuild (and the hover/click disruption it causes)
+    // unless the changed-file set actually differs from what's rendered.
     let snapshot = FilesContentSnapshot(worktreeDir: worktreeDir, files: changedFiles)
     guard snapshot != lastFilesSnapshot else { return }
     lastFilesSnapshot = snapshot

--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -51,11 +51,19 @@ final class DFSidebar: NSView {
     return img
   }()
 
-  /// Guard against reentrant calls to `refreshWorktrees()`.
-  /// `Process.waitUntilExit()` pumps the run loop, which can dispatch queued
-  /// notifications and re-enter this method mid-iteration — splicing one
-  /// project's worktree rows under another project's header.
-  private var isRefreshingWorktrees = false
+  /// Serial queue for `git worktree list` spawns. Enumeration used to run on
+  /// the main thread, where `Process.waitUntilExit()` both hitched the UI on
+  /// a cold/busy repo and pumped the run loop (which needed a reentrancy
+  /// guard to stop queued notifications from splicing rows mid-rebuild).
+  private let worktreeEnumQueue = DispatchQueue(
+    label: "com.draftframe.sidebar.worktree-enum", qos: .userInitiated)
+
+  /// True while an enumeration pass is on `worktreeEnumQueue`. Further
+  /// `refreshWorktrees()` calls set `worktreeRefreshQueued` so at most one
+  /// pass runs at a time and bursts of `.sessionsDidChange` pings collapse
+  /// into a single trailing re-check (same pattern as `filesRefreshInFlight`).
+  private var worktreeRefreshInFlight = false
+  private var worktreeRefreshQueued = false
 
   /// Comparable snapshot of everything that affects the rendered worktree
   /// rows. `.sessionsDidChange` fires every ~1.5s from JSONL/status pollers
@@ -403,30 +411,72 @@ final class DFSidebar: NSView {
     refreshWorktrees()
   }
 
+  /// Listings from the most recent completed enumeration. Lets UI-only
+  /// changes (sort order, expand/collapse, active project) repaint in the
+  /// same frame instead of waiting a git round-trip.
+  private var lastEnumerated: [String: [WorktreeManager.Worktree]]?
+
   @objc func refreshWorktrees() {
-    // Process.waitUntilExit() inside getWorktrees(for:) pumps the run loop,
-    // which can dispatch a queued .sessionsDidChange notification and re-enter
-    // this method. The reentrant call clears the stack and rebuilds it, but
-    // then the original call resumes appending rows — splicing one project's
-    // worktrees under another project's header. Guard against that here;
-    // schedule a fresh pass after the current one finishes so the final state
-    // is always consistent.
-    guard !isRefreshingWorktrees else {
-      DispatchQueue.main.async { [weak self] in self?.refreshWorktrees() }
+    // Repaint synchronously from cached listings first — sort, collapse, and
+    // selection changes must land this frame to feel instant. The background
+    // enumeration below then re-applies only if git reports something
+    // different (the content snapshot guard makes it a no-op otherwise).
+    if let cached = lastEnumerated {
+      applyWorktreeResults(cached)
+    }
+
+    guard !worktreeRefreshInFlight else {
+      worktreeRefreshQueued = true
       return
     }
-    isRefreshingWorktrees = true
-    defer { isRefreshingWorktrees = false }
+    worktreeRefreshInFlight = true
+    // A fresh enumeration reads the latest state, so any queued request is
+    // satisfied by this run.
+    worktreeRefreshQueued = false
 
+    let projectPaths = ProjectManager.shared.projects.map { $0.path }
+    worktreeEnumQueue.async { [weak self] in
+      // Always fetch every project's worktrees, including collapsed ones, so
+      // the rows exist in the stack and can be hidden/shown via animator()
+      // without tearing the view down on every expand/collapse.
+      var worktreesPerProject: [String: [WorktreeManager.Worktree]] = [:]
+      for path in projectPaths {
+        worktreesPerProject[path] = Self.enumerateWorktrees(for: path)
+      }
+      DispatchQueue.main.async {
+        guard let self = self else { return }
+        self.worktreeRefreshInFlight = false
+        self.lastEnumerated = worktreesPerProject
+        self.applyWorktreeResults(worktreesPerProject)
+        if self.worktreeRefreshQueued {
+          self.worktreeRefreshQueued = false
+          self.refreshWorktrees()
+        }
+      }
+    }
+  }
+
+  /// Render enumeration results against CURRENT main-thread state: project
+  /// list/order, expansion, active dir, and the in-flight sets are all
+  /// re-read here, so anything that changed while git ran can't paint stale
+  /// rows. Only the worktree listings themselves come from the background
+  /// pass.
+  private func applyWorktreeResults(
+    _ enumerated: [String: [WorktreeManager.Worktree]]
+  ) {
     let projects = sortedProjects()
     let activeDir = SessionManager.shared.projectDir
 
-    // Always fetch every project's worktrees, including collapsed ones, so
-    // the rows exist in the stack and can be hidden/shown via animator()
-    // without tearing the view down on every expand/collapse.
+    // A project added while the enumeration ran has no listing yet — render
+    // it empty and queue a trailing pass so its rows appear right away
+    // instead of waiting for the next status tick.
+    if projects.contains(where: { enumerated[$0.path] == nil }) {
+      worktreeRefreshQueued = true
+    }
+
     var worktreesPerProject: [String: [WorktreeManager.Worktree]] = [:]
     for project in projects {
-      worktreesPerProject[project.path] = getWorktrees(for: project.path)
+      worktreesPerProject[project.path] = (enumerated[project.path] ?? [])
         .filter { !pendingRemovals.contains($0.path) }
     }
 
@@ -859,8 +909,11 @@ final class DFSidebar: NSView {
     NSPasteboard.general.setString(path, forType: .string)
   }
 
-  /// Get worktrees for a specific project directory.
-  private func getWorktrees(for projectPath: String) -> [WorktreeManager.Worktree] {
+  /// Get worktrees for a specific project directory. Spawns git and blocks
+  /// until it exits — call from `worktreeEnumQueue`, never the main thread.
+  private nonisolated static func enumerateWorktrees(for projectPath: String)
+    -> [WorktreeManager.Worktree]
+  {
     // Scrub GIT_* env vars so a stray GIT_DIR/GIT_WORK_TREE inherited from
     // the launching session doesn't redirect git to the wrong repo.
     let env = ProcessInfo.processInfo.environment
@@ -1234,7 +1287,7 @@ final class DFSidebar: NSView {
     let path: String
   }
 
-  private static func gitChangedFiles(in dir: String) -> [ChangedFile] {
+  private nonisolated static func gitChangedFiles(in dir: String) -> [ChangedFile] {
     let env = ProcessInfo.processInfo.environment
       .filter { !$0.key.hasPrefix("GIT_") }
 

--- a/Sources/DraftFrameKit/DFStatusBar.swift
+++ b/Sources/DraftFrameKit/DFStatusBar.swift
@@ -39,9 +39,15 @@ final class DFStatusBar: NSView {
     layer?.backgroundColor = Theme.surface1.cgColor
     buildUI()
 
+    // Shows cost/token totals and the active session's model — usage and
+    // list events cover those; state flips don't change anything here.
     NotificationCenter.default.addObserver(
       self, selector: #selector(refresh),
-      name: .sessionsDidChange, object: nil
+      name: .sessionUsageDidChange, object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(refresh),
+      name: .sessionListDidChange, object: nil
     )
     NotificationCenter.default.addObserver(
       self, selector: #selector(refresh),
@@ -144,7 +150,7 @@ final class DFStatusBar: NSView {
   }
 
   /// Resolve the branch off the main thread: `refresh()` runs on every
-  /// `.sessionsDidChange` tick (~40x/min while an agent works) and spawning
+  /// usage tick (roughly once a second while an agent works) and spawning
   /// git synchronously there blocks event delivery — on a cold or busy repo
   /// long enough to beachball. At most one lookup is in flight; ticks that
   /// arrive mid-lookup are dropped (the next tick re-checks anyway).

--- a/Sources/DraftFrameKit/DFStatusBar.swift
+++ b/Sources/DraftFrameKit/DFStatusBar.swift
@@ -20,7 +20,9 @@ final class DFStatusBar: NSView {
   private var costLabel: NSTextField!
   private var modelLabel: NSTextField!
   private var micIndicator: NSImageView!
-  private var refreshTimer: Timer?
+  /// `nonisolated(unsafe)` so the (never-raced) invalidate in deinit
+  /// compiles; every other access is on the main actor.
+  private nonisolated(unsafe) var refreshTimer: Timer?
 
   // Concurrent so a git that hangs (dead network mount, wedged fsmonitor)
   // can't wedge the recovery lookup behind it on a serial queue.
@@ -61,7 +63,10 @@ final class DFStatusBar: NSView {
 
     // Periodic refresh for git branch and token counts
     refreshTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
-      self?.refresh()
+      // Scheduled on the main run loop, matching the view's isolation.
+      MainActor.assumeIsolated {
+        self?.refresh()
+      }
     }
   }
 
@@ -166,10 +171,11 @@ final class DFStatusBar: NSView {
     branchRefreshGeneration += 1
     let generation = branchRefreshGeneration
     let dir = SessionManager.shared.branchLookupDirectory
-    branchQueue.async { [weak self] in
-      let branch = SessionManager.shared.currentBranch(inDirectory: dir)
-      DispatchQueue.main.async {
-        guard let self else { return }
+    let bar = self
+    branchQueue.async {
+      let branch = SessionManager.currentBranch(inDirectory: dir)
+      DispatchQueue.main.async { [weak bar] in
+        guard let self = bar else { return }
         // A presumed-hung lookup that eventually returns must not clear a
         // newer lookup's flag or overwrite its result.
         guard generation == self.branchRefreshGeneration else { return }

--- a/Sources/DraftFrameKit/DFTerminalPane.swift
+++ b/Sources/DraftFrameKit/DFTerminalPane.swift
@@ -429,14 +429,19 @@ final class DFTerminalPane: NSView {
       load.revealTimer = Timer.scheduledTimer(
         withTimeInterval: Self.claudeRevealDelay, repeats: false
       ) { [weak self] _ in
-        self?.finishLoading(for: sessionID)
+        // Timers fire on the main run loop, matching the view's isolation.
+        MainActor.assumeIsolated {
+          self?.finishLoading(for: sessionID)
+        }
       }
     }
 
     load.maxTimer = Timer.scheduledTimer(
       withTimeInterval: Self.claudeMaxLoad, repeats: false
     ) { [weak self] _ in
-      self?.finishLoading(for: sessionID)
+      MainActor.assumeIsolated {
+        self?.finishLoading(for: sessionID)
+      }
     }
   }
 

--- a/Sources/DraftFrameKit/DFTerminalPane.swift
+++ b/Sources/DraftFrameKit/DFTerminalPane.swift
@@ -80,9 +80,15 @@ final class DFTerminalPane: NSView {
     layer?.backgroundColor = Theme.bg.cgColor
     setupUI()
 
+    // Tabs render names (list) and state dots (state); usage ticks don't
+    // touch the tab strip.
     NotificationCenter.default.addObserver(
       self, selector: #selector(sessionsChanged),
-      name: .sessionsDidChange, object: nil
+      name: .sessionListDidChange, object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(sessionsChanged),
+      name: .sessionStateDidChange, object: nil
     )
     NotificationCenter.default.addObserver(
       self, selector: #selector(activeSessionChanged),
@@ -497,7 +503,7 @@ final class DFTerminalPane: NSView {
       let newName = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !newName.isEmpty else { return }
       session.name = newName
-      NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+      SessionEvents.postListChanged()
     }
   }
 

--- a/Sources/DraftFrameKit/DFToast.swift
+++ b/Sources/DraftFrameKit/DFToast.swift
@@ -4,6 +4,7 @@ import AppKit
 /// above the status bar. Fades in, auto-dismisses after `duration` seconds,
 /// and can be dismissed early with a click. Showing a new toast replaces any
 /// toast currently on screen.
+@MainActor
 enum DFToast {
   private static weak var current: ToastView?
 
@@ -84,7 +85,10 @@ enum DFToast {
           animator().alphaValue = 0
         },
         completionHandler: { [weak self] in
-          self?.removeFromSuperview()
+          // Animation completions run on the main thread.
+          MainActor.assumeIsolated {
+            self?.removeFromSuperview()
+          }
         })
     }
   }

--- a/Sources/DraftFrameKit/DFToolkitEditor.swift
+++ b/Sources/DraftFrameKit/DFToolkitEditor.swift
@@ -2,6 +2,7 @@ import AppKit
 
 /// In-app editor window for the toolkit JSON config.
 /// Singleton — reuses the same window across show/hide cycles.
+@MainActor
 final class DFToolkitEditor: NSObject, NSTextFieldDelegate, NSWindowDelegate {
   static let shared = DFToolkitEditor()
 

--- a/Sources/DraftFrameKit/DirectoryWatcher.swift
+++ b/Sources/DraftFrameKit/DirectoryWatcher.swift
@@ -10,7 +10,10 @@ import Foundation
 /// Used to keep the sidebar CHANGES list live even when files are edited
 /// outside of agent activity (e.g. the user's own editor), which the
 /// notification-driven refresh alone would miss.
-final class DirectoryWatcher {
+/// `@unchecked Sendable`: `onChange` is immutable and `stream` is only
+/// touched in init/deinit; the conformance lets the FSEvents callback pass
+/// the unretained reference back to the main queue.
+final class DirectoryWatcher: @unchecked Sendable {
   private var stream: FSEventStreamRef?
   private let onChange: () -> Void
 

--- a/Sources/DraftFrameKit/JSONLTailer.swift
+++ b/Sources/DraftFrameKit/JSONLTailer.swift
@@ -22,7 +22,10 @@ import Foundation
 ///
 /// `findLatest`, `onSwitch`, and `onLines` are all invoked on the tailer's
 /// private queue.
-final class JSONLTailer {
+/// `@unchecked Sendable`: every piece of mutable state is confined to the
+/// private serial `queue`; the conformance lets dispatch-source handlers
+/// capture `self` without per-site ceremony.
+final class JSONLTailer: @unchecked Sendable {
 
   private let findLatest: () -> String?
   /// Called when a newer file replaces the tracked one, before any of the

--- a/Sources/DraftFrameKit/NewWorktreeDialog.swift
+++ b/Sources/DraftFrameKit/NewWorktreeDialog.swift
@@ -10,6 +10,7 @@ import AppKit
 ///   session's kickoff prompt.
 /// - Existing Branch: a single field naming a branch to check out into a
 ///   worktree. Opens a session in it with no kickoff prompt.
+@MainActor
 enum NewWorktreeDialog {
   enum Mode {
     case newBranch
@@ -80,6 +81,7 @@ enum NewWorktreeDialog {
 
   /// The themed sheet window plus its controls. Instances keep themselves
   /// alive in `active` while presented.
+  @MainActor
   private final class Sheet: NSObject, NSTextFieldDelegate {
     private static var active: [Sheet] = []
 

--- a/Sources/DraftFrameKit/NotificationManager.swift
+++ b/Sources/DraftFrameKit/NotificationManager.swift
@@ -3,6 +3,10 @@ import UserNotifications
 
 /// Manages macOS notifications for session state transitions.
 /// Sends alerts when background sessions need attention or finish generating.
+/// Main-actor isolated; the UNUserNotificationCenter delegate callbacks are
+/// `nonisolated` (the framework calls them on its own queue) and hop to the
+/// main actor where they touch session state.
+@MainActor
 final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
   static let shared = NotificationManager()
 
@@ -27,9 +31,8 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     )
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
+  // No deinit: the shared singleton never deallocates, so observer removal
+  // there would be dead code.
 
   // MARK: - Authorization
 
@@ -121,12 +124,10 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
   // MARK: - Dock Badge
 
   private func updateDockBadge(count: Int) {
-    DispatchQueue.main.async {
-      if count > 0 {
-        NSApp.dockTile.badgeLabel = "\(count)"
-      } else {
-        NSApp.dockTile.badgeLabel = nil
-      }
+    if count > 0 {
+      NSApp.dockTile.badgeLabel = "\(count)"
+    } else {
+      NSApp.dockTile.badgeLabel = nil
     }
   }
 
@@ -134,7 +135,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 
   /// Show notifications even when the app is in the foreground (but we filter
   /// to background sessions above, so this is a safety net).
-  func userNotificationCenter(
+  nonisolated func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification,
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
@@ -143,7 +144,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
   }
 
   /// When user clicks a notification, switch to the relevant session.
-  func userNotificationCenter(
+  nonisolated func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     didReceive response: UNNotificationResponse,
     withCompletionHandler completionHandler: @escaping () -> Void
@@ -153,11 +154,13 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     let components = identifier.split(separator: "-", maxSplits: 1)
     if components.count == 2, let uuid = UUID(uuidString: String(components[1])) {
       DispatchQueue.main.async {
-        let sessions = SessionManager.shared.sessions
-        if let idx = sessions.firstIndex(where: { $0.id == uuid }) {
-          SessionManager.shared.switchTo(index: idx)
+        MainActor.assumeIsolated {
+          let sessions = SessionManager.shared.sessions
+          if let idx = sessions.firstIndex(where: { $0.id == uuid }) {
+            SessionManager.shared.switchTo(index: idx)
+          }
+          NSApp.activate(ignoringOtherApps: true)
         }
-        NSApp.activate(ignoringOtherApps: true)
       }
     }
     completionHandler()

--- a/Sources/DraftFrameKit/NotificationManager.swift
+++ b/Sources/DraftFrameKit/NotificationManager.swift
@@ -9,9 +9,6 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
   /// Whether we can use UNUserNotificationCenter (requires app bundle).
   private let canUseNotifications = Bundle.main.bundleIdentifier != nil
 
-  /// Tracks previous state per session ID so we can detect transitions.
-  private var previousStates: [UUID: SessionState] = [:]
-
   private override init() {
     super.init()
 
@@ -20,8 +17,13 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     }
 
     NotificationCenter.default.addObserver(
-      self, selector: #selector(sessionsChanged),
-      name: .sessionsDidChange, object: nil
+      self, selector: #selector(sessionStateChanged(_:)),
+      name: .sessionStateDidChange, object: nil
+    )
+    // A needs-attention session being closed shrinks the badge count.
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(sessionListChanged),
+      name: .sessionListDidChange, object: nil
     )
   }
 
@@ -44,53 +46,43 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 
   // MARK: - Session State Observation
 
-  @objc private func sessionsChanged() {
-    let sessions = SessionManager.shared.sessions
-    let activeSession = SessionManager.shared.activeSession
-
-    var needsAttentionCount = 0
-
-    for session in sessions {
-      let previous = previousStates[session.id] ?? .idle
-      let current = session.state
-
-      // Count sessions needing attention for badge
-      if current == .needsAttention {
-        needsAttentionCount += 1
-      }
-
+  /// The typed event carries the transition, so there's no per-session state
+  /// diffing (or its cleanup) here anymore.
+  @objc private func sessionStateChanged(_ note: Notification) {
+    if let change = SessionEvents.stateChange(note),
+      let session = SessionManager.shared.sessions.first(where: { $0.id == change.id }),
       // Only notify for non-active (background) sessions
-      let isActive = session.id == activeSession?.id
-      if !isActive && previous != current {
-        // Transition to .needsAttention
-        if current == .needsAttention {
-          sendNotification(
-            title: "Session needs attention",
-            body: "\(session.name) \u{2014} permission prompt or error",
-            identifier: "needsAttention-\(session.id.uuidString)"
-          )
-        }
-
-        // Transition from non-idle to .userInput (the agent finished)
-        if current == .userInput && previous != .idle {
-          sendNotification(
-            title: "\(session.agent.displayName) finished",
-            body: "\(session.name) is waiting for input",
-            identifier: "finished-\(session.id.uuidString)"
-          )
-        }
+      session.id != SessionManager.shared.activeSession?.id
+    {
+      // Transition to .needsAttention
+      if change.new == .needsAttention {
+        sendNotification(
+          title: "Session needs attention",
+          body: "\(session.name) \u{2014} permission prompt or error",
+          identifier: "needsAttention-\(session.id.uuidString)"
+        )
       }
 
-      // Update tracked state
-      previousStates[session.id] = current
+      // Transition from non-idle to .userInput (the agent finished)
+      if change.new == .userInput && change.old != .idle {
+        sendNotification(
+          title: "\(session.agent.displayName) finished",
+          body: "\(session.name) is waiting for input",
+          identifier: "finished-\(session.id.uuidString)"
+        )
+      }
     }
 
-    // Clean up states for removed sessions
-    let activeIDs = Set(sessions.map { $0.id })
-    previousStates = previousStates.filter { activeIDs.contains($0.key) }
+    refreshDockBadge()
+  }
 
-    // Update dock badge
-    updateDockBadge(count: needsAttentionCount)
+  @objc private func sessionListChanged() {
+    refreshDockBadge()
+  }
+
+  private func refreshDockBadge() {
+    let count = SessionManager.shared.sessions.filter { $0.state == .needsAttention }.count
+    updateDockBadge(count: count)
   }
 
   // MARK: - Public API for Watchdogs

--- a/Sources/DraftFrameKit/PRMonitor.swift
+++ b/Sources/DraftFrameKit/PRMonitor.swift
@@ -107,6 +107,11 @@ extension Notification.Name {
 /// Singleton that polls `gh pr view` for each session with a worktree,
 /// surfaces CI status, and fires auto-fix / auto-merge / auto-archive
 /// actions when configured.
+///
+/// Main-actor isolated: all mutable state (status, timers, config) lives on
+/// the main actor. The blocking `gh` spawns are `nonisolated` and run on the
+/// private queue, handing results back via explicit main-queue hops.
+@MainActor
 final class PRMonitor {
   static let shared = PRMonitor()
 
@@ -156,10 +161,8 @@ final class PRMonitor {
     )
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-    for timer in timers.values { timer.cancel() }
-  }
+  // No deinit: the shared singleton never deallocates, so observer removal
+  // and timer cancellation there would be dead code.
 
   // MARK: - Public
 
@@ -249,7 +252,7 @@ final class PRMonitor {
 
   // MARK: - Polling (runs on `queue`)
 
-  private func poll(sessionID: UUID, worktreePath: String) {
+  nonisolated private func poll(sessionID: UUID, worktreePath: String) {
     guard FileManager.default.fileExists(atPath: worktreePath) else {
       NSLog("[PRMonitor] poll skipped: path does not exist: %@", worktreePath)
       return
@@ -272,7 +275,9 @@ final class PRMonitor {
         "[PRMonitor] no PR for %@ (gh output: %@)",
         worktreePath, preview.isEmpty ? "<empty>" : String(preview))
       DispatchQueue.main.async { [weak self] in
-        self?.clearStatus(sessionID: sessionID)
+        MainActor.assumeIsolated {
+          self?.clearStatus(sessionID: sessionID)
+        }
       }
       return
     }
@@ -292,11 +297,13 @@ final class PRMonitor {
     )
 
     DispatchQueue.main.async { [weak self] in
-      self?.updateStatus(sessionID: sessionID, worktreePath: worktreePath, newStatus: status)
+      MainActor.assumeIsolated {
+        self?.updateStatus(sessionID: sessionID, worktreePath: worktreePath, newStatus: status)
+      }
     }
   }
 
-  private func computeRollup(checks: [PRCheck]) -> PRRollup {
+  nonisolated private func computeRollup(checks: [PRCheck]) -> PRRollup {
     if checks.isEmpty { return .none }
     if checks.contains(where: { c in c.conclusion.map { PRConclusion.failing.contains($0) } ?? false
     }) {
@@ -394,11 +401,13 @@ final class PRMonitor {
       )
       NSLog("[PRMonitor] auto-merge output: %@", output)
       DispatchQueue.main.async {
-        let session = SessionManager.shared.sessions.first(where: { $0.id == sessionID })
-        NotificationManager.shared.sendWatchdogNotification(
-          title: "PR #\(status.number) auto-merge requested",
-          body: "Merge queued on \(session?.name ?? "session")"
-        )
+        MainActor.assumeIsolated {
+          let session = SessionManager.shared.sessions.first(where: { $0.id == sessionID })
+          NotificationManager.shared.sendWatchdogNotification(
+            title: "PR #\(status.number) auto-merge requested",
+            body: "Merge queued on \(session?.name ?? "session")"
+          )
+        }
       }
     }
   }
@@ -448,7 +457,7 @@ final class PRMonitor {
 
   // MARK: - gh shell out
 
-  private func runGH(args: [String], cwd: String) -> String {
+  nonisolated private func runGH(args: [String], cwd: String) -> String {
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
     proc.arguments = ["gh"] + args

--- a/Sources/DraftFrameKit/PRMonitor.swift
+++ b/Sources/DraftFrameKit/PRMonitor.swift
@@ -148,9 +148,11 @@ final class PRMonitor {
 
   private init() {
     loadConfig()
+    // Timers track session membership and worktree paths, both of which
+    // only move on list changes — state/usage ticks are irrelevant here.
     NotificationCenter.default.addObserver(
       self, selector: #selector(sessionsChanged),
-      name: .sessionsDidChange, object: nil
+      name: .sessionListDidChange, object: nil
     )
   }
 

--- a/Sources/DraftFrameKit/PTYStreamAnalyzer.swift
+++ b/Sources/DraftFrameKit/PTYStreamAnalyzer.swift
@@ -3,6 +3,12 @@ import Foundation
 /// Analyzes raw PTY byte stream in real-time to detect agent session state.
 /// Strips ANSI escape sequences and tracks alternate buffer mode, frame boundaries,
 /// and content patterns.
+///
+/// Main-actor isolated: `feed` is driven by SwiftTerm's `dataReceived`,
+/// which arrives on the main queue, and the debounced frame analysis is
+/// scheduled there too. The annotation pins the contract so a future caller
+/// can't feed bytes from another thread and race the rolling buffer.
+@MainActor
 final class PTYStreamAnalyzer {
 
   /// Which agent's TUI this stream carries. Selects the marker set used for
@@ -10,20 +16,20 @@ final class PTYStreamAnalyzer {
   /// never misclassify the other's session.
   var agent: AgentKind = .claude
 
-  var onStateChange: ((SessionState) -> Void)?
-  var onContextWindowChange: ((Int) -> Void)?
+  var onStateChange: (@MainActor (SessionState) -> Void)?
+  var onContextWindowChange: (@MainActor (Int) -> Void)?
   /// Fired once, the first time we positively identify Claude Code's TUI in
   /// the stream — used to dismiss the startup loading overlay. Claude renders
   /// in the main screen buffer (no alternate-screen switch to key off of), so
   /// we detect it by the markers it paints: see `detectClaudeReady`.
-  var onClaudeReady: (() -> Void)?
+  var onClaudeReady: (@MainActor () -> Void)?
   /// Guards `onClaudeReady` so it fires at most once per (re)start.
   private var claudeReadyFired = false
   /// Fired when the TUI reveals the active model. Codex prints
   /// "model:   gpt-5.6-sol   /model to change" in its startup banner —
   /// the only model signal available before the first turn is written to
   /// the rollout. Fires only when `agent == .codex`.
-  var onModelDetected: ((String) -> Void)?
+  var onModelDetected: (@MainActor (String) -> Void)?
   private var lastDetectedModel: String?
 
   private(set) var state: SessionState = .idle
@@ -87,7 +93,10 @@ final class PTYStreamAnalyzer {
     // Debounce frame analysis — run 50ms after last data chunk
     frameTimer?.cancel()
     let work = DispatchWorkItem { [weak self] in
-      self?.analyzeFrame()
+      // Scheduled on the main queue below, matching this class's isolation.
+      MainActor.assumeIsolated {
+        self?.analyzeFrame()
+      }
     }
     frameTimer = work
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)

--- a/Sources/DraftFrameKit/ProjectManager.swift
+++ b/Sources/DraftFrameKit/ProjectManager.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Manages the list of opened projects and their expanded/collapsed state.
 /// Persists to ~/.config/draftframe/projects.json.
+@MainActor
 final class ProjectManager {
   static let shared = ProjectManager()
 
@@ -49,7 +50,7 @@ final class ProjectManager {
     Self.sort(projects, by: sortOrder, activeProjectPaths: activeProjectPaths)
   }
 
-  static func sort(
+  nonisolated static func sort(
     _ projects: [Project], by order: SortOrder, activeProjectPaths: Set<String>
   ) -> [Project] {
     switch order {

--- a/Sources/DraftFrameKit/QABridge.swift
+++ b/Sources/DraftFrameKit/QABridge.swift
@@ -307,7 +307,9 @@ import SwiftTerm
     /// Text of the session's visible terminal screen — what a human QA would
     /// see. `ClaudeTerminalView` pins the viewport to the live screen, so this
     /// tracks program output. `requestedLines` keeps only the last N rows.
-    @MainActor private func readBuffer(tv: ClaudeTerminalView, requestedLines: Int?) -> [String: Any] {
+    @MainActor private func readBuffer(tv: ClaudeTerminalView, requestedLines: Int?)
+      -> [String: Any]
+    {
       let term = tv.getTerminal()
       var lines: [String] = []
       for row in 0..<term.rows {

--- a/Sources/DraftFrameKit/QABridge.swift
+++ b/Sources/DraftFrameKit/QABridge.swift
@@ -21,7 +21,10 @@ import SwiftTerm
   ///
   /// The env-var gate means the bridge never runs for normal users — packaged
   /// builds don't set it, and there is no UI to turn it on.
-  public final class QABridge {
+  /// `@unchecked Sendable`: the mutable fields are written once during
+  /// `start` (on the main thread, before the accept thread spawns) and only
+  /// read afterwards; all command handling hops to the main actor.
+  public final class QABridge: @unchecked Sendable {
     public static let shared = QABridge()
 
     private weak var appDelegate: DFAppDelegate?
@@ -119,20 +122,23 @@ import SwiftTerm
         if buf[0..<n].contains(0x0A) { break }
       }
 
-      var response: [String: Any]
+      // Serialize the response inside the main.sync block so only Sendable
+      // Data crosses back to the socket thread, not a [String: Any].
+      var out: Data
       if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
         let cmd = obj["cmd"] as? String
       {
-        var result: [String: Any] = [:]
-        DispatchQueue.main.sync {
-          result = self.handle(cmd: cmd, params: obj)
+        out = DispatchQueue.main.sync {
+          MainActor.assumeIsolated {
+            let result = self.handle(cmd: cmd, params: obj)
+            return (try? JSONSerialization.data(withJSONObject: result))
+              ?? Data(#"{"ok":false,"error":"unencodable response"}"#.utf8)
+          }
         }
-        response = result
       } else {
-        response = ["ok": false, "error": "invalid request: expected JSON with a \"cmd\" field"]
+        out = Data(
+          #"{"ok":false,"error":"invalid request: expected JSON with a \"cmd\" field"}"#.utf8)
       }
-
-      guard var out = try? JSONSerialization.data(withJSONObject: response) else { return }
       out.append(0x0A)
       out.withUnsafeBytes { raw in
         var sent = 0
@@ -146,6 +152,7 @@ import SwiftTerm
 
     // MARK: - Command dispatch (main thread)
 
+    @MainActor
     private func handle(cmd: String, params: [String: Any]) -> [String: Any] {
       switch cmd {
       case "ping":
@@ -247,7 +254,7 @@ import SwiftTerm
 
     // MARK: - Helpers
 
-    private func resolveSession(_ params: [String: Any]) -> Session? {
+    @MainActor private func resolveSession(_ params: [String: Any]) -> Session? {
       let mgr = SessionManager.shared
       if let idx = params["index"] as? Int {
         guard idx >= 0, idx < mgr.sessions.count else { return nil }
@@ -256,7 +263,7 @@ import SwiftTerm
       return mgr.activeSession
     }
 
-    private func sessionList() -> [[String: Any]] {
+    @MainActor private func sessionList() -> [[String: Any]] {
       let mgr = SessionManager.shared
       return mgr.sessions.enumerated().map { i, s in
         [
@@ -276,7 +283,7 @@ import SwiftTerm
       }
     }
 
-    private func appState() -> [String: Any] {
+    @MainActor private func appState() -> [String: Any] {
       let mgr = SessionManager.shared
       var state: [String: Any] = [
         "ok": true,
@@ -300,7 +307,7 @@ import SwiftTerm
     /// Text of the session's visible terminal screen — what a human QA would
     /// see. `ClaudeTerminalView` pins the viewport to the live screen, so this
     /// tracks program output. `requestedLines` keeps only the last N rows.
-    private func readBuffer(tv: ClaudeTerminalView, requestedLines: Int?) -> [String: Any] {
+    @MainActor private func readBuffer(tv: ClaudeTerminalView, requestedLines: Int?) -> [String: Any] {
       let term = tv.getTerminal()
       var lines: [String] = []
       for row in 0..<term.rows {
@@ -328,7 +335,7 @@ import SwiftTerm
     /// Capture a window's actual pixels into a PNG via CGWindowListCreateImage.
     /// Capturing our own process's windows needs no screen-recording permission,
     /// and unlike `cacheDisplay` it includes SwiftTerm's terminal rendering.
-    private func screenshot(to path: String, window which: String) -> [String: Any] {
+    @MainActor private func screenshot(to path: String, window which: String) -> [String: Any] {
       let win: NSWindow?
       switch which {
       case "quick":
@@ -366,7 +373,7 @@ import SwiftTerm
     /// Find a menu item by its title path (e.g. ["View", "Toggle Dashboard"])
     /// and perform its action. The action fires asynchronously so an item that
     /// opens a modal (About, alerts) can't deadlock the bridge's reply.
-    private func invokeMenu(titles: [String]) -> [String: Any] {
+    @MainActor private func invokeMenu(titles: [String]) -> [String: Any] {
       guard var menu = NSApp.mainMenu else {
         return ["ok": false, "error": "no main menu"]
       }

--- a/Sources/DraftFrameKit/QuitConfirmationHUD.swift
+++ b/Sources/DraftFrameKit/QuitConfirmationHUD.swift
@@ -5,6 +5,7 @@ import AppKit
 /// after the confirmation window lapses. Purely visual — the double-press logic
 /// lives in `DFAppDelegate.requestQuit`; this just mirrors that window on screen
 /// so a second press lands while the hint is still up.
+@MainActor
 final class QuitConfirmationHUD {
   static let shared = QuitConfirmationHUD()
 
@@ -46,8 +47,11 @@ final class QuitConfirmationHUD {
         panel.animator().alphaValue = 0
       },
       completionHandler: { [weak self] in
-        panel.orderOut(nil)
-        self?.panel = nil
+        // Animation completions run on the main thread.
+        MainActor.assumeIsolated {
+          panel.orderOut(nil)
+          self?.panel = nil
+        }
       })
   }
 

--- a/Sources/DraftFrameKit/SessionJSONLWatcher.swift
+++ b/Sources/DraftFrameKit/SessionJSONLWatcher.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Watches a Claude Code JSONL session log and accumulates token usage/cost.
-final class SessionJSONLWatcher {
+/// `@unchecked Sendable`: mutable state is confined to the tailer's serial
+/// queue, except the assistant-text pair, which is lock-guarded.
+final class SessionJSONLWatcher: @unchecked Sendable {
 
   // MARK: - Model pricing per token (derived from per-1M-token rates)
 
@@ -28,7 +30,9 @@ final class SessionJSONLWatcher {
 
   // MARK: - Public state
 
-  typealias UpdateCallback = (
+  /// Delivered on the main queue (the values are snapshots taken on the
+  /// tailer's queue), feeding main-actor session state.
+  typealias UpdateCallback = @MainActor (
     _ cost: Double,
     _ tokensIn: Int,
     _ tokensOut: Int,
@@ -203,7 +207,9 @@ final class SessionJSONLWatcher {
       let lifeIn = lifetimeTokensIn
       let lifeOut = lifetimeTokensOut
       DispatchQueue.main.async { [weak self] in
-        self?.onUpdate(cost, tIn, tOut, model, ctx, maxCtx, lifeCost, lifeIn, lifeOut)
+        MainActor.assumeIsolated {
+          self?.onUpdate(cost, tIn, tOut, model, ctx, maxCtx, lifeCost, lifeIn, lifeOut)
+        }
       }
     }
   }

--- a/Sources/DraftFrameKit/SessionJSONLWatcher.swift
+++ b/Sources/DraftFrameKit/SessionJSONLWatcher.swift
@@ -66,13 +66,17 @@ final class SessionJSONLWatcher {
   /// detected.
   private(set) var parsedMaxContextTokens: Int = 0
 
-  /// Most recent assistant text response parsed from the JSONL stream.
-  /// Used by the dashboard's cross-session summary view. Nil until the
-  /// session has produced its first text-bearing assistant message.
-  private(set) var latestAssistantText: String?
-
-  /// Timestamp of the most recent assistant text.
-  private(set) var latestAssistantAt: Date?
+  /// Most recent assistant text response parsed from the JSONL stream, and
+  /// its timestamp. Nil until the session has produced its first
+  /// text-bearing assistant message. Written on the tailer's queue but read
+  /// from the main thread by the dashboard's summary view, so access goes
+  /// through a lock — unlike the other counters, these aren't delivered as
+  /// snapshots via the main-dispatched `onUpdate`.
+  var latestAssistantText: String? { assistantTextLock.withLock { _latestAssistantText } }
+  var latestAssistantAt: Date? { assistantTextLock.withLock { _latestAssistantAt } }
+  private let assistantTextLock = NSLock()
+  private var _latestAssistantText: String?
+  private var _latestAssistantAt: Date?
 
   // MARK: - Private
 
@@ -127,13 +131,25 @@ final class SessionJSONLWatcher {
 
   private func claudeProjectDir() -> String? {
     let home = FileManager.default.homeDirectoryForCurrentUser.path
-    let encoded = Self.encodePath(workingDirectory)
-    let dir = "\(home)/.claude/projects/\(encoded)"
-    var isDir: ObjCBool = false
-    guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDir), isDir.boolValue else {
-      return nil
+    // Claude Code encodes its own getcwd — the symlink-RESOLVED path
+    // (/private/tmp, not /tmp) — while the session may hold the unresolved
+    // spelling. Try the resolved spelling first, then the raw one, so
+    // cost/tokens don't silently stay at zero for symlinked project paths.
+    // POSIX realpath, NOT Foundation's resolvingSymlinksInPath: the latter
+    // strips the /private prefix back off, which un-does exactly the
+    // resolution we need to mirror here.
+    var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
+    let resolved =
+      workingDirectory.withCString { realpath($0, &buf) != nil }
+      ? String(cString: buf) : workingDirectory
+    for candidate in [resolved, workingDirectory] {
+      let dir = "\(home)/.claude/projects/\(Self.encodePath(candidate))"
+      var isDir: ObjCBool = false
+      if FileManager.default.fileExists(atPath: dir, isDirectory: &isDir), isDir.boolValue {
+        return dir
+      }
     }
-    return dir
+    return nil
   }
 
   private func findLatestJSONL() -> String? {
@@ -248,8 +264,10 @@ final class SessionJSONLWatcher {
     if let text = Self.extractText(from: message["content"]),
       !text.isEmpty
     {
-      latestAssistantText = text
-      latestAssistantAt = Date()
+      assistantTextLock.withLock {
+        _latestAssistantText = text
+        _latestAssistantAt = Date()
+      }
     }
 
     // Accumulate usage once per API response, not once per JSONL line —

--- a/Sources/DraftFrameKit/SessionJSONLWatcher.swift
+++ b/Sources/DraftFrameKit/SessionJSONLWatcher.swift
@@ -32,17 +32,18 @@ final class SessionJSONLWatcher: @unchecked Sendable {
 
   /// Delivered on the main queue (the values are snapshots taken on the
   /// tailer's queue), feeding main-actor session state.
-  typealias UpdateCallback = @MainActor (
-    _ cost: Double,
-    _ tokensIn: Int,
-    _ tokensOut: Int,
-    _ model: String,
-    _ contextTokens: Int,
-    _ maxContextTokens: Int,
-    _ lifetimeCost: Double,
-    _ lifetimeTokensIn: Int,
-    _ lifetimeTokensOut: Int
-  ) -> Void
+  typealias UpdateCallback =
+    @MainActor (
+      _ cost: Double,
+      _ tokensIn: Int,
+      _ tokensOut: Int,
+      _ model: String,
+      _ contextTokens: Int,
+      _ maxContextTokens: Int,
+      _ lifetimeCost: Double,
+      _ lifetimeTokensIn: Int,
+      _ lifetimeTokensOut: Int
+    ) -> Void
 
   /// Cost/tokens for the CURRENT claude run only (the session file we're
   /// watching now). Reset when we switch to a newer session file, so these

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -1,10 +1,52 @@
 import AppKit
 import SwiftTerm
 
-/// Notification posted whenever session list or session state changes.
+/// Typed per-session notifications. Consumers subscribe only to the events
+/// that affect what they render, replacing the old catch-all
+/// `.sessionsDidChange` that woke every observer for every cost tick.
 extension Notification.Name {
-  static let sessionsDidChange = Notification.Name("DFSessionsDidChange")
+  /// Membership, order, or naming of the session list changed
+  /// (create, close, move, rename, worktree rename).
+  static let sessionListDidChange = Notification.Name("DFSessionListDidChange")
+  /// One session's `SessionState` changed. Payload via `SessionEvents`.
+  static let sessionStateDidChange = Notification.Name("DFSessionStateDidChange")
+  /// One session's cost/token/model/context figures changed.
+  /// Payload via `SessionEvents`.
+  static let sessionUsageDidChange = Notification.Name("DFSessionUsageDidChange")
   static let activeSessionDidChange = Notification.Name("DFActiveSessionDidChange")
+}
+
+/// Posting and payload parsing for the typed session notifications, so the
+/// userInfo keys live in exactly one place.
+enum SessionEvents {
+  static let sessionIDKey = "sessionID"
+  static let oldStateKey = "oldState"
+  static let newStateKey = "newState"
+
+  static func postListChanged() {
+    NotificationCenter.default.post(name: .sessionListDidChange, object: nil)
+  }
+
+  static func postStateChanged(id: UUID, old: SessionState, new: SessionState) {
+    NotificationCenter.default.post(
+      name: .sessionStateDidChange, object: nil,
+      userInfo: [sessionIDKey: id, oldStateKey: old, newStateKey: new])
+  }
+
+  static func postUsageChanged(id: UUID) {
+    NotificationCenter.default.post(
+      name: .sessionUsageDidChange, object: nil, userInfo: [sessionIDKey: id])
+  }
+
+  static func stateChange(_ note: Notification)
+    -> (id: UUID, old: SessionState, new: SessionState)?
+  {
+    guard let id = note.userInfo?[sessionIDKey] as? UUID,
+      let old = note.userInfo?[oldStateKey] as? SessionState,
+      let new = note.userInfo?[newStateKey] as? SessionState
+    else { return nil }
+    return (id, old, new)
+  }
 }
 
 /// State of an agent session, detected from its status file or terminal output.
@@ -121,8 +163,9 @@ final class Session {
     ptyAnalyzer.onContextWindowChange = { [weak self] maxTokens in
       guard let self = self else { return }
       self.maxContextTokens = maxTokens
+      let id = self.id
       DispatchQueue.main.async {
-        NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+        SessionEvents.postUsageChanged(id: id)
       }
     }
   }
@@ -151,13 +194,15 @@ final class Session {
       if maxContextTokens > 0 {
         self.maxContextTokens = maxContextTokens
       }
-      NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+      SessionEvents.postUsageChanged(id: self.id)
     }
 
     let applyState: (SessionState) -> Void = { [weak self] newState in
       guard let self = self else { return }
+      let old = self.state
+      guard old != newState else { return }
       self.state = newState
-      NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+      SessionEvents.postStateChanged(id: self.id, old: old, new: newState)
     }
 
     switch agent {
@@ -190,7 +235,7 @@ final class Session {
       ptyAnalyzer.onModelDetected = { [weak self] model in
         guard let self = self, self.model != model else { return }
         self.model = model
-        NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+        SessionEvents.postUsageChanged(id: self.id)
       }
     }
   }
@@ -412,7 +457,7 @@ final class SessionManager {
     sessions.append(session)
     activeSessionIndex = sessions.count - 1
 
-    NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+    SessionEvents.postListChanged()
     NotificationCenter.default.post(name: .activeSessionDidChange, object: nil)
 
     tv.window?.layoutIfNeeded()
@@ -464,7 +509,7 @@ final class SessionManager {
       activeSessionIndex = sessions.count - 1
     }
 
-    NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+    SessionEvents.postListChanged()
     NotificationCenter.default.post(name: .activeSessionDidChange, object: nil)
   }
 
@@ -486,7 +531,7 @@ final class SessionManager {
     session.worktreePath = newPath
     session.stopWatchers()
     session.startWatchers(directory: newPath)
-    NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+    SessionEvents.postListChanged()
   }
 
   /// Close session by ID.
@@ -512,7 +557,7 @@ final class SessionManager {
       activeSessionIndex = newIdx
     }
 
-    NotificationCenter.default.post(name: .sessionsDidChange, object: nil)
+    SessionEvents.postListChanged()
     if activeSessionIndex != priorActiveIndex {
       NotificationCenter.default.post(name: .activeSessionDidChange, object: nil)
     }

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -78,7 +78,11 @@ enum SessionState: String {
   }
 }
 
-/// A single terminal session.
+/// A single terminal session. Main-actor isolated: every field here feeds
+/// the UI directly, and the watcher pipelines already deliver their updates
+/// on the main queue — the annotation makes that contract compiler-checked
+/// instead of conventional.
+@MainActor
 final class Session {
   let id: UUID
   var name: String
@@ -197,7 +201,7 @@ final class Session {
       SessionEvents.postUsageChanged(id: self.id)
     }
 
-    let applyState: (SessionState) -> Void = { [weak self] newState in
+    let applyState: @MainActor @Sendable (SessionState) -> Void = { [weak self] newState in
       guard let self = self else { return }
       let old = self.state
       guard old != newState else { return }
@@ -250,7 +254,9 @@ final class Session {
   }
 }
 
-/// Singleton managing all terminal sessions.
+/// Singleton managing all terminal sessions. Main-actor isolated; the few
+/// helpers that background queues legitimately call are marked `nonisolated`.
+@MainActor
 final class SessionManager {
   static let shared = SessionManager()
 
@@ -579,8 +585,9 @@ final class SessionManager {
   }
 
   /// Get the current git branch for `dir`. Spawns git and blocks until it
-  /// exits, so call from a background queue.
-  func currentBranch(inDirectory dir: String) -> String {
+  /// exits, so call from a background queue (hence static + nonisolated:
+  /// callers need no reference to the main-actor singleton).
+  nonisolated static func currentBranch(inDirectory dir: String) -> String {
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
     proc.arguments = ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]

--- a/Sources/DraftFrameKit/SessionPersistence.swift
+++ b/Sources/DraftFrameKit/SessionPersistence.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// Saves and restores session names and worktree paths across app launches.
 /// Persists to ~/.config/draftframe/sessions.json.
+/// Main-actor isolated: reads and mutates SessionManager state.
+@MainActor
 final class SessionPersistence {
   static let shared = SessionPersistence()
 

--- a/Sources/DraftFrameKit/SessionStatusRegistry.swift
+++ b/Sources/DraftFrameKit/SessionStatusRegistry.swift
@@ -25,9 +25,9 @@ actor SessionStatusRegistry {
   /// out-of-order stop()-before-subscribe harmless: the late subscribe is
   /// refused because the probe already answers false.
   typealias IsActive = @Sendable () -> Bool
-  /// Fired on the main queue, only when the state differs from the last
+  /// Fired on the main actor, only when the state differs from the last
   /// one reported to this subscriber.
-  typealias Callback = @Sendable (SessionState) -> Void
+  typealias Callback = @MainActor @Sendable (SessionState) -> Void
 
   private struct Subscriber {
     let cwd: String
@@ -144,7 +144,9 @@ actor SessionStatusRegistry {
       let isActive = sub.isActive
       DispatchQueue.main.async {
         guard isActive() else { return }
-        callback(state)
+        MainActor.assumeIsolated {
+          callback(state)
+        }
       }
     }
   }

--- a/Sources/DraftFrameKit/SessionStatusRegistry.swift
+++ b/Sources/DraftFrameKit/SessionStatusRegistry.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// Single shared watcher over Claude Code's per-pid status files
+/// (`~/.claude/sessions/<pid>.json`), fanning authoritative session state
+/// out to every subscribed session.
+///
+/// Each `SessionStatusWatcher` used to run its own 1.5s poll that read and
+/// JSON-parsed EVERY file in the directory — N sessions paid N identical
+/// scans, plus a `kill(pid, 0)` per file per session. The registry performs
+/// one scan per tick, resolves the newest live pid file per subscribed cwd,
+/// and reports state changes per subscriber. Write-event sources on the
+/// matched files keep latency below the poll cadence, exactly like the old
+/// per-session watcher.
+///
+/// An actor so every piece of mutable state (subscribers, dedup, sources,
+/// poll task) is compiler-enforced serial — the registry is touched from the
+/// main queue (subscribe/stop), file-event handlers, and its own poll loop.
+actor SessionStatusRegistry {
+
+  static let shared = SessionStatusRegistry()
+
+  /// Liveness probe supplied by the subscribing handle. Checked before
+  /// every callback (and each tick) so a handle stopped or deallocated
+  /// between actor hops is pruned instead of notified — this also makes an
+  /// out-of-order stop()-before-subscribe harmless: the late subscribe is
+  /// refused because the probe already answers false.
+  typealias IsActive = @Sendable () -> Bool
+  /// Fired on the main queue, only when the state differs from the last
+  /// one reported to this subscriber.
+  typealias Callback = @Sendable (SessionState) -> Void
+
+  private struct Subscriber {
+    let cwd: String
+    let isActive: IsActive
+    let callback: Callback
+    var lastReported: SessionState?
+  }
+
+  /// One parsed status file. `state` is nil when the JSON is readable but
+  /// carries no recognized `status` — the subscriber keeps its last state,
+  /// matching the old watcher's behavior for torn/partial writes.
+  private struct PidFile {
+    let path: String
+    let cwd: String
+    let startedAt: Double
+    let state: SessionState?
+  }
+
+  private let sessionsDir: String
+  private var subscribers: [UUID: Subscriber] = [:]
+  private var pollTask: Task<Void, Never>?
+  /// One write-event source per pid file currently matched to a subscriber.
+  private var fileSources: [String: DispatchSourceFileSystemObject] = [:]
+
+  /// `sessionsDir` overrides the status-file location for tests.
+  init(sessionsDir: String = "\(NSHomeDirectory())/.claude/sessions") {
+    self.sessionsDir = sessionsDir
+  }
+
+  func subscribe(
+    id: UUID, cwd: String,
+    isActive: @escaping IsActive,
+    onUpdate: @escaping Callback
+  ) {
+    guard isActive() else { return }
+    // Match on symlink-resolved paths: Claude Code writes the realpath into
+    // the pid file (e.g. /private/tmp) while sessions may hold the
+    // unresolved spelling (/tmp) — an exact compare would leave any project
+    // under a symlinked path without authoritative status forever.
+    subscribers[id] = Subscriber(
+      cwd: Self.resolved(cwd), isActive: isActive, callback: onUpdate)
+    startPollingIfNeeded()
+    tick()
+  }
+
+  private static func resolved(_ path: String) -> String {
+    URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+  }
+
+  func unsubscribe(id: UUID) {
+    subscribers.removeValue(forKey: id)
+    if subscribers.isEmpty { stopPolling() }
+  }
+
+  // MARK: - Poll loop
+
+  private func startPollingIfNeeded() {
+    guard pollTask == nil else { return }
+    // Weak so a test-owned registry that is dropped without unsubscribing
+    // doesn't keep itself alive through its own loop.
+    pollTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        guard let self else { return }
+        await self.tick()
+      }
+    }
+  }
+
+  private func stopPolling() {
+    pollTask?.cancel()
+    pollTask = nil
+    for source in fileSources.values { source.cancel() }
+    fileSources = [:]
+    resolvedCwdCache = [:]
+  }
+
+  // MARK: - Scan / dispatch
+
+  /// One pass: prune dead subscribers, scan the directory once, resolve the
+  /// newest live pid file per cwd, retarget write-event sources, and report
+  /// state changes.
+  private func tick() {
+    subscribers = subscribers.filter { $0.value.isActive() }
+    guard !subscribers.isEmpty else {
+      stopPolling()
+      return
+    }
+
+    var bestByCwd: [String: PidFile] = [:]
+    for file in scanPidFiles() {
+      if let current = bestByCwd[file.cwd], current.startedAt > file.startedAt { continue }
+      bestByCwd[file.cwd] = file
+    }
+
+    let matchedPaths = Set(subscribers.values.compactMap { bestByCwd[$0.cwd]?.path })
+    retargetFileSources(to: matchedPaths)
+
+    for (id, var sub) in subscribers {
+      let state: SessionState
+      if let file = bestByCwd[sub.cwd] {
+        // Readable file without a recognized status — keep the last state.
+        guard let parsed = file.state else { continue }
+        state = parsed
+      } else {
+        // No live claude here — terminal is at the shell prompt.
+        state = .idle
+      }
+      guard state != sub.lastReported else { continue }
+      sub.lastReported = state
+      subscribers[id] = sub
+
+      let callback = sub.callback
+      let isActive = sub.isActive
+      DispatchQueue.main.async {
+        guard isActive() else { return }
+        callback(state)
+      }
+    }
+  }
+
+  /// Symlink resolution hits the filesystem per path component; pid-file
+  /// cwds repeat on every 1.5s tick, so cache them. Live pid files number a
+  /// handful, so the cache stays tiny; it's dropped with the poll loop.
+  private var resolvedCwdCache: [String: String] = [:]
+
+  private func resolvedCwd(_ cwd: String) -> String {
+    if let cached = resolvedCwdCache[cwd] { return cached }
+    let resolved = Self.resolved(cwd)
+    resolvedCwdCache[cwd] = resolved
+    return resolved
+  }
+
+  /// Read and parse every pid file once, keeping only live processes
+  /// (`kill(pid, 0) == 0`, same liveness test the per-session watcher used).
+  private func scanPidFiles() -> [PidFile] {
+    guard let names = try? FileManager.default.contentsOfDirectory(atPath: sessionsDir) else {
+      return []
+    }
+    var out: [PidFile] = []
+    for name in names where name.hasSuffix(".json") {
+      let full = "\(sessionsDir)/\(name)"
+      guard let data = try? Data(contentsOf: URL(fileURLWithPath: full)),
+        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let cwd = obj["cwd"] as? String,
+        let pid = obj["pid"] as? Int, kill(pid_t(pid), 0) == 0
+      else { continue }
+
+      let state: SessionState?
+      switch obj["status"] as? String {
+      case "busy": state = .generating
+      case "waiting": state = .needsAttention
+      case "idle": state = .userInput
+      default: state = nil
+      }
+      out.append(
+        PidFile(
+          path: full,
+          cwd: resolvedCwd(cwd),
+          startedAt: (obj["startedAt"] as? Double) ?? 0,
+          state: state))
+    }
+    return out
+  }
+
+  // MARK: - File-event sources
+
+  private func retargetFileSources(to paths: Set<String>) {
+    for (path, source) in fileSources where !paths.contains(path) {
+      source.cancel()
+      fileSources.removeValue(forKey: path)
+    }
+    for path in paths where fileSources[path] == nil {
+      attachFileSource(path: path)
+    }
+  }
+
+  private func attachFileSource(path: String) {
+    let fd = open(path, O_EVTONLY)
+    guard fd >= 0 else { return }
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fd,
+      eventMask: [.write, .extend, .delete, .rename],
+      queue: DispatchQueue.global(qos: .utility)
+    )
+    source.setEventHandler { [weak self] in
+      guard let self else { return }
+      Task { await self.tick() }
+    }
+    // The cancel handler is the SOLE closer of the event fd. `cancel()` is
+    // async; closing anywhere else would free the fd number for reuse before
+    // the handler runs, making it close an unrelated fd (libdispatch
+    // EV_VANISHED trap).
+    source.setCancelHandler { close(fd) }
+    source.resume()
+    fileSources[path] = source
+  }
+}

--- a/Sources/DraftFrameKit/SessionStatusWatcher.swift
+++ b/Sources/DraftFrameKit/SessionStatusWatcher.swift
@@ -1,148 +1,44 @@
 import Foundation
+import os
 
-/// Watches the per-pid state file Claude Code writes at
-/// `~/.claude/sessions/<pid>.json` and reports authoritative session status.
-/// Far more reliable than PTY parsing — TUI redraws can push our textual
-/// markers (like "esc to interrupt") out of the rolling buffer before we
-/// observe them, but Claude Code keeps the JSON file fresh as state changes.
+/// Reports authoritative session status from the per-pid state file Claude
+/// Code writes at `~/.claude/sessions/<pid>.json`. Far more reliable than
+/// PTY parsing — TUI redraws can push our textual markers (like "esc to
+/// interrupt") out of the rolling buffer before we observe them, but Claude
+/// Code keeps the JSON file fresh as state changes.
+///
+/// Thin per-session handle over the shared `SessionStatusRegistry`, which
+/// owns the single directory scan and file-event machinery for every session
+/// at once. `onUpdate` fires on the main queue, only when the state changes.
 final class SessionStatusWatcher {
 
   typealias UpdateCallback = (SessionState) -> Void
 
-  private let cwd: String
-  private let onUpdate: UpdateCallback
-
-  private let queue = DispatchQueue(label: "com.draftframe.status-watcher", qos: .utility)
-  private var pollTimer: DispatchSourceTimer?
-  private var fileSource: DispatchSourceFileSystemObject?
-  private var watchedPath: String?
-  private var watchedFD: Int32 = -1
-  private var lastReported: SessionState?
+  private let id = UUID()
+  /// Consulted by the registry (its liveness probe) before every callback.
+  /// A lock rather than a plain Bool because the probe runs from the
+  /// registry's executor and the main queue.
+  private let stopped = OSAllocatedUnfairLock(initialState: false)
 
   init(cwd: String, onUpdate: @escaping UpdateCallback) {
-    self.cwd = cwd
-    self.onUpdate = onUpdate
-
-    // Re-resolve the matching pid file frequently so a new claude run, a
-    // restart, or an atomic-rename of the JSON (which invalidates our
-    // file-event subscription) all converge within ~1.5s.
-    let timer = DispatchSource.makeTimerSource(queue: queue)
-    timer.schedule(deadline: .now() + 0.5, repeating: 1.5)
-    timer.setEventHandler { [weak self] in
-      self?.tick()
+    let id = self.id
+    let stopped = self.stopped
+    // The subscribe and unsubscribe hops are separate Tasks and may land on
+    // the actor in either order; the registry refuses a subscribe whose
+    // probe already answers false, so a stop() racing init is safe.
+    Task {
+      await SessionStatusRegistry.shared.subscribe(
+        id: id, cwd: cwd,
+        isActive: { !stopped.withLock { $0 } },
+        onUpdate: onUpdate)
     }
-    timer.resume()
-    pollTimer = timer
   }
 
   deinit { stop() }
 
   func stop() {
-    pollTimer?.cancel()
-    pollTimer = nil
-    // The cancel handler owns `close(fd)`. Don't close it here too —
-    // `cancel()` is async, so a synchronous close would free the fd number
-    // for reuse before the handler runs, and the handler would then close a
-    // now-unrelated fd (libdispatch EV_VANISHED trap).
-    fileSource?.cancel()
-    fileSource = nil
-    watchedFD = -1
-  }
-
-  private func tick() {
-    let resolved = findMatchingPidFile()
-    if resolved != watchedPath {
-      detachFileWatcher()
-      watchedPath = resolved
-      if let path = resolved {
-        attachFileWatcher(path: path)
-      }
-    }
-    readAndDispatch()
-  }
-
-  /// Find the most recently started pid file whose `cwd` matches and whose
-  /// pid is still alive. Returns nil when no live claude is running here.
-  private func findMatchingPidFile() -> String? {
-    let dir = "\(NSHomeDirectory())/.claude/sessions"
-    guard let names = try? FileManager.default.contentsOfDirectory(atPath: dir) else {
-      return nil
-    }
-
-    var bestPath: String?
-    var bestStartedAt: Double = 0
-
-    for name in names where name.hasSuffix(".json") {
-      let full = "\(dir)/\(name)"
-      guard let data = try? Data(contentsOf: URL(fileURLWithPath: full)),
-        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let pidCwd = obj["cwd"] as? String, pidCwd == cwd,
-        let pid = obj["pid"] as? Int, kill(pid_t(pid), 0) == 0
-      else { continue }
-      let startedAt = (obj["startedAt"] as? Double) ?? 0
-      if startedAt >= bestStartedAt {
-        bestStartedAt = startedAt
-        bestPath = full
-      }
-    }
-    return bestPath
-  }
-
-  private func attachFileWatcher(path: String) {
-    let fd = open(path, O_EVTONLY)
-    guard fd >= 0 else { return }
-    watchedFD = fd
-    let source = DispatchSource.makeFileSystemObjectSource(
-      fileDescriptor: fd,
-      eventMask: [.write, .extend, .delete, .rename],
-      queue: queue
-    )
-    source.setEventHandler { [weak self] in
-      self?.readAndDispatch()
-    }
-    source.setCancelHandler { [weak self] in
-      if let self = self, self.watchedFD == fd { self.watchedFD = -1 }
-      close(fd)
-    }
-    source.resume()
-    fileSource = source
-  }
-
-  private func detachFileWatcher() {
-    // Sole closer of the event fd is the source's cancel handler; closing
-    // it synchronously here would race fd reuse and crash libdispatch.
-    fileSource?.cancel()
-    fileSource = nil
-    watchedPath = nil
-    watchedFD = -1
-  }
-
-  private func readAndDispatch() {
-    guard let path = watchedPath else {
-      // No live claude here — terminal is at the shell prompt.
-      report(.idle)
-      return
-    }
-    guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let status = obj["status"] as? String
-    else { return }
-
-    let state: SessionState
-    switch status {
-    case "busy": state = .generating
-    case "waiting": state = .needsAttention
-    case "idle": state = .userInput
-    default: return
-    }
-    report(state)
-  }
-
-  private func report(_ state: SessionState) {
-    guard state != lastReported else { return }
-    lastReported = state
-    DispatchQueue.main.async { [weak self] in
-      self?.onUpdate(state)
-    }
+    stopped.withLock { $0 = true }
+    let id = self.id
+    Task { await SessionStatusRegistry.shared.unsubscribe(id: id) }
   }
 }

--- a/Sources/DraftFrameKit/SessionStatusWatcher.swift
+++ b/Sources/DraftFrameKit/SessionStatusWatcher.swift
@@ -12,7 +12,7 @@ import os
 /// at once. `onUpdate` fires on the main queue, only when the state changes.
 final class SessionStatusWatcher {
 
-  typealias UpdateCallback = (SessionState) -> Void
+  typealias UpdateCallback = @MainActor @Sendable (SessionState) -> Void
 
   private let id = UUID()
   /// Consulted by the registry (its liveness probe) before every callback.

--- a/Sources/DraftFrameKit/Shortcuts.swift
+++ b/Sources/DraftFrameKit/Shortcuts.swift
@@ -1,6 +1,8 @@
 import AppKit
 
 /// Registers global keyboard shortcuts for the app.
+/// Main-actor isolated: local event monitors deliver on the main thread.
+@MainActor
 final class ShortcutManager {
   static let shared = ShortcutManager()
 

--- a/Sources/DraftFrameKit/TerminalLoadingOverlay.swift
+++ b/Sources/DraftFrameKit/TerminalLoadingOverlay.swift
@@ -59,7 +59,7 @@ final class TerminalLoadingOverlay: NSView {
   }
 
   /// Fade out, detach from the view hierarchy, then run `completion`.
-  func fadeOut(completion: @escaping () -> Void) {
+  func fadeOut(completion: @escaping @MainActor @Sendable () -> Void) {
     NSAnimationContext.runAnimationGroup(
       { ctx in
         ctx.duration = 0.22
@@ -67,8 +67,11 @@ final class TerminalLoadingOverlay: NSView {
         animator().alphaValue = 0
       },
       completionHandler: { [weak self] in
-        self?.removeFromSuperview()
-        completion()
+        // Animation completions run on the main thread.
+        MainActor.assumeIsolated {
+          self?.removeFromSuperview()
+          completion()
+        }
       })
   }
 

--- a/Sources/DraftFrameKit/ToolkitManager.swift
+++ b/Sources/DraftFrameKit/ToolkitManager.swift
@@ -13,6 +13,7 @@ import Foundation
 /// survive worktree cleanup and `git clean`. The active config path is
 /// re-evaluated whenever the project directory changes. A file watcher
 /// auto-reloads on save.
+@MainActor
 final class ToolkitManager {
   static let shared = ToolkitManager()
 
@@ -60,10 +61,8 @@ final class ToolkitManager {
     )
   }
 
-  deinit {
-    fileWatcherSource?.cancel()
-    NotificationCenter.default.removeObserver(self)
-  }
+  // No deinit: the shared singleton never deallocates, so watcher/observer
+  // cleanup there would be dead code.
 
   /// Re-evaluate which toolkit.json to use when the active session changes.
   /// Keyed by the project dir (not the session's worktree) so every session

--- a/Sources/DraftFrameKit/ToolkitRunManager.swift
+++ b/Sources/DraftFrameKit/ToolkitRunManager.swift
@@ -3,6 +3,7 @@ import AppKit
 /// A single execution of a toolkit command, owning the process and its
 /// streamed output. Runs outlive the popover that displays them, so closing
 /// the (transient) popover mid-run doesn't lose the process or its log.
+@MainActor
 final class ToolkitRun {
   let id = UUID()
   let commandKey: String
@@ -39,6 +40,7 @@ final class ToolkitRun {
 /// Owns all toolkit runs and their processes, decoupled from the popover UI.
 /// Output is streamed in as it's produced and broadcast via notifications;
 /// any view can attach to a run at any point in its lifecycle.
+@MainActor
 final class ToolkitRunManager {
   static let shared = ToolkitRunManager()
 
@@ -90,19 +92,29 @@ final class ToolkitRunManager {
         return
       }
       guard let chunk = String(data: data, encoding: .utf8) else { return }
+      // Immutable bindings so the main-queue hop captures lets, not the
+      // handler closure's weak vars (a Swift 6 sendability error).
+      let manager = self
+      let target = run
       DispatchQueue.main.async {
-        guard let self = self, let run = run else { return }
-        self.append(chunk, to: run)
+        MainActor.assumeIsolated {
+          guard let manager, let target else { return }
+          manager.append(chunk, to: target)
+        }
       }
     }
 
     proc.terminationHandler = { [weak run] p in
+      let status = p.terminationStatus
+      let target = run
       DispatchQueue.main.async {
-        guard let run = run else { return }
-        run.exitCode = p.terminationStatus
-        run.process = nil
-        NotificationCenter.default.post(
-          name: .toolkitRunStateDidChange, object: nil, userInfo: ["runID": run.id])
+        MainActor.assumeIsolated {
+          guard let run = target else { return }
+          run.exitCode = status
+          run.process = nil
+          NotificationCenter.default.post(
+            name: .toolkitRunStateDidChange, object: nil, userInfo: ["runID": run.id])
+        }
       }
     }
 

--- a/Sources/DraftFrameKit/UpdateManager.swift
+++ b/Sources/DraftFrameKit/UpdateManager.swift
@@ -41,6 +41,11 @@ struct UpdateError: LocalizedError {
 
 // MARK: - Update Manager
 
+/// Main-actor isolated: it drives alert and progress UI. The URLSession
+/// delegate callbacks are `nonisolated` to satisfy the protocol, but the
+/// download session is configured with `delegateQueue: .main`, so their
+/// bodies re-assert main-actor isolation.
+@MainActor
 final class UpdateManager: NSObject, URLSessionDownloadDelegate {
   static let shared = UpdateManager()
 
@@ -181,48 +186,58 @@ final class UpdateManager: NSObject, URLSessionDownloadDelegate {
 
   // MARK: - URLSessionDownloadDelegate
 
-  func urlSession(
+  nonisolated func urlSession(
     _ session: URLSession, downloadTask: URLSessionDownloadTask,
     didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
     totalBytesExpectedToWrite: Int64
   ) {
-    if totalBytesExpectedToWrite > 0 {
-      let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
-      progressIndicator?.doubleValue = progress * 100
+    MainActor.assumeIsolated {
+      if totalBytesExpectedToWrite > 0 {
+        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        progressIndicator?.doubleValue = progress * 100
+      }
     }
   }
 
-  func urlSession(
+  nonisolated func urlSession(
     _ session: URLSession, downloadTask task: URLSessionDownloadTask,
     didFinishDownloadingTo location: URL
   ) {
-    dismissDownloadProgress()
+    // The file at `location` must be moved before this method returns, so
+    // everything stays synchronous inside the isolation assertion.
+    MainActor.assumeIsolated {
+      dismissDownloadProgress()
 
-    guard let asset = downloadingAsset else { return }
-    downloadingAsset = nil
+      guard let asset = downloadingAsset else { return }
+      downloadingAsset = nil
 
-    let downloads = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0]
-    let dest = downloads.appendingPathComponent(asset.name)
+      let downloads = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0]
+      let dest = downloads.appendingPathComponent(asset.name)
 
-    do {
-      try? FileManager.default.removeItem(at: dest)
-      try FileManager.default.moveItem(at: location, to: dest)
-      showReadyToInstallAlert(dmgPath: dest.path)
-    } catch {
-      showErrorAlert("Failed to save update: \(error.localizedDescription)")
+      do {
+        try? FileManager.default.removeItem(at: dest)
+        try FileManager.default.moveItem(at: location, to: dest)
+        showReadyToInstallAlert(dmgPath: dest.path)
+      } catch {
+        showErrorAlert("Failed to save update: \(error.localizedDescription)")
+      }
     }
   }
 
-  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-    if let error = error {
-      dismissDownloadProgress()
-      showErrorAlert("Download failed: \(error.localizedDescription)")
+  nonisolated func urlSession(
+    _ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?
+  ) {
+    MainActor.assumeIsolated {
+      if let error = error {
+        dismissDownloadProgress()
+        showErrorAlert("Download failed: \(error.localizedDescription)")
+      }
     }
   }
 
   // MARK: - Install
 
-  private static let expectedTeamID = "49V6GRJ827"
+  private nonisolated static let expectedTeamID = "49V6GRJ827"
 
   private func installUpdate(dmgPath: String) {
     showProgressPanel(label: "Installing update\u{2026}", indeterminate: true)
@@ -244,7 +259,7 @@ final class UpdateManager: NSObject, URLSessionDownloadDelegate {
 
   // Mounts the DMG, verifies the new app's signature, swaps it into place,
   // and cleans up. Returns the installed app path. Runs off the main thread.
-  private static func performInstall(dmgPath: String) throws -> String {
+  private nonisolated static func performInstall(dmgPath: String) throws -> String {
     let mountPoint = try mountDMG(dmgPath)
     defer { detachDMG(mountPoint) }
 
@@ -289,7 +304,7 @@ final class UpdateManager: NSObject, URLSessionDownloadDelegate {
 
   // The running bundle's location, unless it isn't a normal writable install
   // (translocated, on a DMG, or a dev build) — then fall back to /Applications.
-  private static func installDestination() -> URL {
+  private nonisolated static func installDestination() -> URL {
     let bundleURL = Bundle.main.bundleURL
     let path = bundleURL.path
     if path.hasSuffix(".app"),
@@ -303,7 +318,7 @@ final class UpdateManager: NSObject, URLSessionDownloadDelegate {
     return URL(fileURLWithPath: "/Applications/DraftFrame.app")
   }
 
-  private static func mountDMG(_ path: String) throws -> String {
+  private nonisolated static func mountDMG(_ path: String) throws -> String {
     let result = try run(
       "/usr/bin/hdiutil", ["attach", path, "-nobrowse", "-noautoopen", "-plist"])
     guard result.status == 0,
@@ -318,11 +333,11 @@ final class UpdateManager: NSObject, URLSessionDownloadDelegate {
     return mountPoint
   }
 
-  private static func detachDMG(_ mountPoint: String) {
+  private nonisolated static func detachDMG(_ mountPoint: String) {
     _ = try? run("/usr/bin/hdiutil", ["detach", mountPoint, "-force"])
   }
 
-  private static func verifySignature(of app: URL) throws {
+  private nonisolated static func verifySignature(of app: URL) throws {
     let verify = try run(
       "/usr/bin/codesign", ["--verify", "--deep", "--strict", app.path])
     guard verify.status == 0 else {
@@ -350,7 +365,7 @@ final class UpdateManager: NSObject, URLSessionDownloadDelegate {
   }
 
   @discardableResult
-  private static func run(
+  private nonisolated static func run(
     _ tool: String, _ args: [String]
   ) throws -> (status: Int32, stdout: Data, stderr: String) {
     let proc = Process()

--- a/Sources/DraftFrameKit/VoiceManager.swift
+++ b/Sources/DraftFrameKit/VoiceManager.swift
@@ -4,6 +4,7 @@ import Speech
 
 /// Push-to-talk voice transcription using on-device SFSpeechRecognizer.
 /// Cmd+Shift+V starts listening; releasing stops and sends transcription to active session.
+@MainActor
 final class VoiceManager {
   static let shared = VoiceManager()
 

--- a/Sources/DraftFrameKit/WatchdogManager.swift
+++ b/Sources/DraftFrameKit/WatchdogManager.swift
@@ -64,9 +64,6 @@ final class WatchdogManager {
   /// Log of all watchdog actions: (timestamp, description).
   private(set) var watchdogLog: [(Date, String)] = []
 
-  /// Tracks previous session states to detect transitions.
-  private var previousStates: [UUID: SessionState] = [:]
-
   /// Timers for periodic watchdogs, keyed by watchdog ID.
   private var periodicTimers: [UUID: Timer] = [:]
 
@@ -74,8 +71,8 @@ final class WatchdogManager {
     loadDefaults()
 
     NotificationCenter.default.addObserver(
-      self, selector: #selector(sessionsChanged),
-      name: .sessionsDidChange, object: nil
+      self, selector: #selector(sessionStateChanged(_:)),
+      name: .sessionStateDidChange, object: nil
     )
   }
 
@@ -206,48 +203,37 @@ final class WatchdogManager {
 
   // MARK: - Session State Observation
 
-  @objc private func sessionsChanged() {
-    let sessions = SessionManager.shared.sessions
+  /// The typed event carries the transition, so there's no per-session state
+  /// diffing (or its cleanup) here anymore.
+  @objc private func sessionStateChanged(_ note: Notification) {
+    guard let change = SessionEvents.stateChange(note),
+      let session = SessionManager.shared.sessions.first(where: { $0.id == change.id })
+    else { return }
 
-    for session in sessions {
-      let previous = previousStates[session.id] ?? .idle
-      let current = session.state
-
-      guard previous != current else { continue }
-
-      // Evaluate all enabled watchdogs
-      for watchdog in watchdogs where watchdog.isEnabled {
-        // Check session scope
-        if let targetID = watchdog.sessionID, targetID != session.id {
-          continue
-        }
-
-        var shouldFire = false
-
-        switch watchdog.trigger {
-        case .needsAttention:
-          shouldFire = current == .needsAttention
-
-        case .idleAfterWork:
-          let wasWorking = previous == .generating || previous == .thinking
-          shouldFire = wasWorking && current == .userInput
-
-        case .periodic:
-          // Periodic triggers are handled by timers, not state transitions
-          break
-        }
-
-        if shouldFire {
-          executeResponse(watchdog.response, for: session, watchdog: watchdog)
-        }
+    for watchdog in watchdogs where watchdog.isEnabled {
+      // Check session scope
+      if let targetID = watchdog.sessionID, targetID != change.id {
+        continue
       }
 
-      previousStates[session.id] = current
-    }
+      let shouldFire: Bool
+      switch watchdog.trigger {
+      case .needsAttention:
+        shouldFire = change.new == .needsAttention
 
-    // Clean up states for removed sessions
-    let activeIDs = Set(sessions.map { $0.id })
-    previousStates = previousStates.filter { activeIDs.contains($0.key) }
+      case .idleAfterWork:
+        let wasWorking = change.old == .generating || change.old == .thinking
+        shouldFire = wasWorking && change.new == .userInput
+
+      case .periodic:
+        // Periodic triggers are handled by timers, not state transitions
+        shouldFire = false
+      }
+
+      if shouldFire {
+        executeResponse(watchdog.response, for: session, watchdog: watchdog)
+      }
+    }
   }
 
   // MARK: - Periodic Timers

--- a/Sources/DraftFrameKit/WatchdogManager.swift
+++ b/Sources/DraftFrameKit/WatchdogManager.swift
@@ -56,6 +56,8 @@ struct Watchdog: Identifiable {
 
 /// Singleton that manages watchdogs — semi-autonomous monitors that watch
 /// Claude sessions and auto-respond when certain conditions are met.
+/// Main-actor isolated: driven by session events and main-runloop timers.
+@MainActor
 final class WatchdogManager {
   static let shared = WatchdogManager()
 
@@ -76,10 +78,9 @@ final class WatchdogManager {
     )
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-    for timer in periodicTimers.values { timer.invalidate() }
-  }
+  // No deinit: the shared singleton never deallocates, so observer removal
+  // and timer invalidation there would be dead code (and deinit can't touch
+  // main-actor state under strict concurrency).
 
   // MARK: - Default Watchdogs
 
@@ -243,7 +244,10 @@ final class WatchdogManager {
 
     let interval = TimeInterval(max(seconds, 1))
     let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-      self?.firePeriodicWatchdog(id: watchdog.id)
+      // Scheduled on the main run loop, matching this class's isolation.
+      MainActor.assumeIsolated {
+        self?.firePeriodicWatchdog(id: watchdog.id)
+      }
     }
     RunLoop.main.add(timer, forMode: .common)
     periodicTimers[watchdog.id] = timer
@@ -287,31 +291,29 @@ final class WatchdogManager {
     case .autoAccept:
       let msg = "\(logPrefix): auto-accepting (sending 'y')"
       appendLog(msg)
-      DispatchQueue.main.async {
-        session.terminalView?.send(txt: "y\r")
-      }
+      session.terminalView?.send(txt: "y\r")
 
     case .sendText(let text):
       let msg = "\(logPrefix): sending text \"\(text)\""
       appendLog(msg)
-      DispatchQueue.main.async {
-        session.terminalView?.send(txt: text + "\r")
-      }
+      session.terminalView?.send(txt: text + "\r")
 
     case .runCommand(let cmd):
       let msg = "\(logPrefix): running command \"\(cmd)\""
       appendLog(msg)
-      runShellCommand(cmd) { [weak self] output in
+      Self.runShellCommand(cmd) { [weak self] output in
         let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
         self?.appendLog("\(logPrefix): command output: \(trimmed)")
-        DispatchQueue.main.async {
-          session.terminalView?.send(txt: trimmed + "\r")
-        }
+        session.terminalView?.send(txt: trimmed + "\r")
       }
     }
   }
 
-  private func runShellCommand(_ command: String, completion: @escaping (String) -> Void) {
+  /// Runs `command` in a login shell off the main thread and delivers its
+  /// output back on the main actor.
+  private nonisolated static func runShellCommand(
+    _ command: String, completion: @escaping @MainActor @Sendable (String) -> Void
+  ) {
     DispatchQueue.global(qos: .userInitiated).async {
       let proc = Process()
       let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
@@ -322,17 +324,18 @@ final class WatchdogManager {
       proc.standardOutput = pipe
       proc.standardError = pipe
 
+      let output: String
       do {
         try proc.run()
         proc.waitUntilExit()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: data, encoding: .utf8) ?? ""
-        DispatchQueue.main.async {
-          completion(output)
-        }
+        output = String(data: data, encoding: .utf8) ?? ""
       } catch {
-        DispatchQueue.main.async {
-          completion("Error: \(error.localizedDescription)")
+        output = "Error: \(error.localizedDescription)"
+      }
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          completion(output)
         }
       }
     }

--- a/Sources/DraftFrameKit/WorktreeManager.swift
+++ b/Sources/DraftFrameKit/WorktreeManager.swift
@@ -2,7 +2,11 @@ import Foundation
 
 /// Manages git worktrees for isolated parallel sessions.
 final class WorktreeManager {
-  static let shared = WorktreeManager()
+  // TODO: WorktreeManager is called from both the main thread and background
+  // queues (worktree removal, pulls); converting it to an actor is the clean
+  // fix. Until then the singleton is declared nonisolated(unsafe), matching
+  // its long-standing cross-thread use.
+  nonisolated(unsafe) static let shared = WorktreeManager()
 
   struct Worktree {
     let path: String

--- a/Tests/DraftFrameTests/PTYStreamAnalyzerTests.swift
+++ b/Tests/DraftFrameTests/PTYStreamAnalyzerTests.swift
@@ -2,6 +2,9 @@ import XCTest
 
 @testable import DraftFrameKit
 
+// XCTest runs test methods on the main thread, matching the analyzer's
+// main-actor isolation.
+@MainActor
 final class PTYStreamAnalyzerTests: XCTestCase {
 
   private var analyzer: PTYStreamAnalyzer!

--- a/Tests/DraftFrameTests/SessionStatusRegistryTests.swift
+++ b/Tests/DraftFrameTests/SessionStatusRegistryTests.swift
@@ -43,10 +43,12 @@ final class SessionStatusRegistryTests: XCTestCase {
     let log = StateLog()
     let exp = expectation(description: "reported")
     let id = UUID()
-    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
-      log.append(state)
-      exp.fulfill()
-    }
+    await registry.subscribe(
+      id: id, cwd: cwd, isActive: { true },
+      onUpdate: { state in
+        log.append(state)
+        exp.fulfill()
+      })
     await fulfillment(of: [exp], timeout: 5)
     XCTAssertEqual(log.states, [.generating])
     await registry.unsubscribe(id: id)
@@ -57,10 +59,12 @@ final class SessionStatusRegistryTests: XCTestCase {
     let log = StateLog()
     let exp = expectation(description: "reported")
     let id = UUID()
-    await registry.subscribe(id: id, cwd: "/tmp/df-nowhere", isActive: { true }) { state in
-      log.append(state)
-      exp.fulfill()
-    }
+    await registry.subscribe(
+      id: id, cwd: "/tmp/df-nowhere", isActive: { true },
+      onUpdate: { state in
+        log.append(state)
+        exp.fulfill()
+      })
     await fulfillment(of: [exp], timeout: 5)
     XCTAssertEqual(log.states, [.idle])
     await registry.unsubscribe(id: id)
@@ -75,10 +79,12 @@ final class SessionStatusRegistryTests: XCTestCase {
     let log = StateLog()
     let exp = expectation(description: "reported")
     let id = UUID()
-    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
-      log.append(state)
-      exp.fulfill()
-    }
+    await registry.subscribe(
+      id: id, cwd: cwd, isActive: { true },
+      onUpdate: { state in
+        log.append(state)
+        exp.fulfill()
+      })
     await fulfillment(of: [exp], timeout: 5)
     XCTAssertEqual(log.states, [.needsAttention])
     await registry.unsubscribe(id: id)
@@ -92,9 +98,11 @@ final class SessionStatusRegistryTests: XCTestCase {
     let log = StateLog()
     // A handle stopped before its subscribe hop lands (stop() racing init)
     // presents an isActive that already answers false.
-    await registry.subscribe(id: UUID(), cwd: cwd, isActive: { false }) { state in
-      log.append(state)
-    }
+    await registry.subscribe(
+      id: UUID(), cwd: cwd, isActive: { false },
+      onUpdate: { state in
+        log.append(state)
+      })
     // Give any (incorrect) callback time to land on main.
     try await Task.sleep(nanoseconds: 200_000_000)
     XCTAssertEqual(log.states, [])
@@ -117,10 +125,12 @@ final class SessionStatusRegistryTests: XCTestCase {
     let log = StateLog()
     let exp = expectation(description: "reported")
     let id = UUID()
-    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
-      log.append(state)
-      exp.fulfill()
-    }
+    await registry.subscribe(
+      id: id, cwd: cwd, isActive: { true },
+      onUpdate: { state in
+        log.append(state)
+        exp.fulfill()
+      })
     await fulfillment(of: [exp], timeout: 5)
     XCTAssertEqual(log.states, [.generating])
     await registry.unsubscribe(id: id)
@@ -138,10 +148,12 @@ final class SessionStatusRegistryTests: XCTestCase {
     let log = StateLog()
     let exp = expectation(description: "reported")
     let id = UUID()
-    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
-      log.append(state)
-      exp.fulfill()
-    }
+    await registry.subscribe(
+      id: id, cwd: cwd, isActive: { true },
+      onUpdate: { state in
+        log.append(state)
+        exp.fulfill()
+      })
     await fulfillment(of: [exp], timeout: 5)
     // The only pid file for this cwd is dead, so the cwd has no live claude.
     XCTAssertEqual(log.states, [.idle])

--- a/Tests/DraftFrameTests/SessionStatusRegistryTests.swift
+++ b/Tests/DraftFrameTests/SessionStatusRegistryTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+final class SessionStatusRegistryTests: XCTestCase {
+
+  private var dir: String!
+
+  override func setUpWithError() throws {
+    dir = NSTemporaryDirectory() + "df-status-registry-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(atPath: dir)
+  }
+
+  /// Callbacks land on the main queue; collect them without racing the test.
+  private final class StateLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _states: [SessionState] = []
+    var states: [SessionState] { lock.withLock { _states } }
+    func append(_ s: SessionState) { lock.withLock { _states.append(s) } }
+  }
+
+  /// Write a pid file the way Claude Code does. Uses our own pid so the
+  /// registry's `kill(pid, 0)` liveness check passes.
+  private func writePidFile(
+    name: String, cwd: String, status: String, startedAt: Double, pid: Int32 = getpid()
+  ) throws {
+    let obj: [String: Any] = [
+      "cwd": cwd, "pid": Int(pid), "startedAt": startedAt, "status": status,
+    ]
+    let data = try JSONSerialization.data(withJSONObject: obj)
+    try data.write(to: URL(fileURLWithPath: dir + "/" + name))
+  }
+
+  func testReportsStateFromMatchingPidFile() async throws {
+    let cwd = "/tmp/df-project-a"
+    try writePidFile(name: "\(getpid()).json", cwd: cwd, status: "busy", startedAt: 100)
+
+    let registry = SessionStatusRegistry(sessionsDir: dir)
+    let log = StateLog()
+    let exp = expectation(description: "reported")
+    let id = UUID()
+    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
+      log.append(state)
+      exp.fulfill()
+    }
+    await fulfillment(of: [exp], timeout: 5)
+    XCTAssertEqual(log.states, [.generating])
+    await registry.unsubscribe(id: id)
+  }
+
+  func testReportsIdleWhenNoPidFileMatches() async throws {
+    let registry = SessionStatusRegistry(sessionsDir: dir)
+    let log = StateLog()
+    let exp = expectation(description: "reported")
+    let id = UUID()
+    await registry.subscribe(id: id, cwd: "/tmp/df-nowhere", isActive: { true }) { state in
+      log.append(state)
+      exp.fulfill()
+    }
+    await fulfillment(of: [exp], timeout: 5)
+    XCTAssertEqual(log.states, [.idle])
+    await registry.unsubscribe(id: id)
+  }
+
+  func testNewestStartedAtWinsForSameCwd() async throws {
+    let cwd = "/tmp/df-project-b"
+    try writePidFile(name: "older.json", cwd: cwd, status: "busy", startedAt: 100)
+    try writePidFile(name: "newer.json", cwd: cwd, status: "waiting", startedAt: 200)
+
+    let registry = SessionStatusRegistry(sessionsDir: dir)
+    let log = StateLog()
+    let exp = expectation(description: "reported")
+    let id = UUID()
+    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
+      log.append(state)
+      exp.fulfill()
+    }
+    await fulfillment(of: [exp], timeout: 5)
+    XCTAssertEqual(log.states, [.needsAttention])
+    await registry.unsubscribe(id: id)
+  }
+
+  func testInactiveSubscriberIsRefusedAndNeverCalled() async throws {
+    let cwd = "/tmp/df-project-c"
+    try writePidFile(name: "\(getpid()).json", cwd: cwd, status: "busy", startedAt: 100)
+
+    let registry = SessionStatusRegistry(sessionsDir: dir)
+    let log = StateLog()
+    // A handle stopped before its subscribe hop lands (stop() racing init)
+    // presents an isActive that already answers false.
+    await registry.subscribe(id: UUID(), cwd: cwd, isActive: { false }) { state in
+      log.append(state)
+    }
+    // Give any (incorrect) callback time to land on main.
+    try await Task.sleep(nanoseconds: 200_000_000)
+    XCTAssertEqual(log.states, [])
+  }
+
+  func testMatchesAcrossSymlinkSpellings() async throws {
+    // Claude Code writes the realpath (/private/tmp/...) into the pid file;
+    // the session may watch the symlinked spelling (/tmp/...). On macOS
+    // /tmp is a symlink to /private/tmp, so these two spellings must match.
+    // Symlink resolution only converges spellings for paths that exist, so
+    // create the directory the way a real project dir would.
+    let cwd = "/tmp/df-symlink-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: cwd, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: cwd) }
+    try writePidFile(
+      name: "\(getpid()).json", cwd: "/private" + cwd,
+      status: "busy", startedAt: 100)
+
+    let registry = SessionStatusRegistry(sessionsDir: dir)
+    let log = StateLog()
+    let exp = expectation(description: "reported")
+    let id = UUID()
+    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
+      log.append(state)
+      exp.fulfill()
+    }
+    await fulfillment(of: [exp], timeout: 5)
+    XCTAssertEqual(log.states, [.generating])
+    await registry.unsubscribe(id: id)
+  }
+
+  func testDeadPidIsIgnored() async throws {
+    let cwd = "/tmp/df-project-d"
+    // PID 0 always fails the kill(pid, 0) liveness probe's intent here —
+    // use an fd-safe guaranteed-dead pid instead: fork would be overkill,
+    // and pid_t(99_999_999) exceeds macOS's max pid, so kill returns ESRCH.
+    try writePidFile(
+      name: "dead.json", cwd: cwd, status: "busy", startedAt: 100, pid: 99_999_999)
+
+    let registry = SessionStatusRegistry(sessionsDir: dir)
+    let log = StateLog()
+    let exp = expectation(description: "reported")
+    let id = UUID()
+    await registry.subscribe(id: id, cwd: cwd, isActive: { true }) { state in
+      log.append(state)
+      exp.fulfill()
+    }
+    await fulfillment(of: [exp], timeout: 5)
+    // The only pid file for this cwd is dead, so the cwd has no live claude.
+    XCTAssertEqual(log.states, [.idle])
+    await registry.unsubscribe(id: id)
+  }
+}


### PR DESCRIPTION
## Summary

Performance and correctness pass over the session/status pipeline, moving the app onto compiler-checked concurrency.

- **Shared status actor**: one `SessionStatusRegistry` actor scans `~/.claude/sessions` per tick and fans state out per subscribed cwd, replacing N per-session watchers each scanning the whole directory. `SessionStatusWatcher` keeps its public API as a thin handle.
- **Typed session events**: the catch-all `.sessionsDidChange` notification is gone. `SessionManager` posts `.sessionListDidChange`, `.sessionStateDidChange` (with the old/new transition), and `.sessionUsageDidChange`; each consumer subscribes only to what it renders. WatchdogManager and NotificationManager consume transitions directly instead of diffing cached state.
- **Main-actor isolation everywhere**: `Session`, `SessionManager`, `PTYStreamAnalyzer`, and every main-driven manager and UI class are `@MainActor`, with `nonisolated` escapes for genuine background work (PR polling, DMG install, git spawns). Delivery hops assert isolation via `MainActor.assumeIsolated`. Strict-concurrency warnings went from 2558 to 1 (a pre-existing `CGWindowListCreateImage` deprecation in the debug-only QA bridge).
- **Sidebar responsiveness**: `git worktree list` no longer runs on the main thread (the run-loop-pumping reentrancy guard is gone), sort/collapse repaint synchronously from cached listings, and content changes rebuild only the affected project's section instead of flashing the whole list. Session cards update state and cost labels in place instead of tearing down once a second while an agent works.
- **Bug fixes**: a data race on the usage watchers' `latestAssistantText` (written on the tailer queue, read from main by the dashboard), and three symlinked-path bugs that left sessions with no authoritative status, zero cost, and the wrong model (exact string compares against realpaths in the status match, the Claude transcript lookup, and the Codex rollout match).

## Testing

- 136 tests pass (6 new for `SessionStatusRegistry`, including symlink-spelling regression coverage)
- Live QA runs via the dfqa bridge: full state lifecycle (idle, generating, idle) through the new pipeline, cost/context/model tracking, dashboard toggle, external worktree pickup, no isolation traps in the app log