### PR TITLE
Persist workspace state and resume Claude sessions across app restarts

### DIFF
--- a/Sources/DraftFrameKit/Agent.swift
+++ b/Sources/DraftFrameKit/Agent.swift
@@ -107,9 +107,17 @@ enum AgentKind: String, CaseIterable {
   /// Full command line that launches this agent with the given model
   /// (empty = the CLI's own default) and, optionally, an initial prompt the
   /// agent starts working on immediately. Both CLIs take the prompt as a
-  /// positional argument.
-  func launchCommand(binPath: String, modelId: String, initialPrompt: String? = nil) -> String {
+  /// positional argument. `resumeSessionId` continues a previous
+  /// conversation instead of starting fresh — Claude Code only; Codex
+  /// sessions always relaunch fresh.
+  func launchCommand(
+    binPath: String, modelId: String, initialPrompt: String? = nil,
+    resumeSessionId: String? = nil
+  ) -> String {
     var cmd = modelId.isEmpty ? binPath : "\(binPath) --model \(modelId)"
+    if self == .claude, let resume = resumeSessionId, !resume.isEmpty {
+      cmd += " --resume \(shellSingleQuote(resume))"
+    }
     if let prompt = initialPrompt, !prompt.isEmpty {
       cmd += " \(shellSingleQuote(prompt))"
     }
@@ -135,7 +143,15 @@ enum AgentPreference {
 protocol UsageWatcher: AnyObject {
   var latestAssistantText: String? { get }
   var latestAssistantAt: Date? { get }
+  /// The agent CLI's own session id, when the watcher can learn it from the
+  /// transcript — what `claude --resume` takes. Nil until known, and always
+  /// nil for agents whose sessions DraftFrame can't resume (Codex).
+  var agentSessionId: String? { get }
   func stop()
+}
+
+extension UsageWatcher {
+  var agentSessionId: String? { nil }
 }
 
 extension SessionJSONLWatcher: UsageWatcher {}

--- a/Sources/DraftFrameKit/DFWindowController.swift
+++ b/Sources/DraftFrameKit/DFWindowController.swift
@@ -334,6 +334,14 @@ final class DFWindowController: NSWindowController {
   /// persistence is that relaunching needs no clicks. A manual mid-session
   /// open keeps the restore-or-fresh prompt.
   func openProject(at path: String, restoreWithoutAsking: Bool = false) {
+    // Re-opening the project that's already open must skip the restore/
+    // create flow below: autosave keeps sessions.json present for the open
+    // project, so falling through would re-offer the Restore prompt and
+    // duplicate every live session (each resuming a conversation another
+    // tab is still attached to).
+    let alreadyOpen =
+      SessionManager.shared.projectDir == path && !SessionManager.shared.sessions.isEmpty
+
     // Set the project directory
     SessionManager.shared.projectDir = path
     FileManager.default.changeCurrentDirectoryPath(path)
@@ -347,6 +355,8 @@ final class DFWindowController: NSWindowController {
     // Update window title
     let dirName = (path as NSString).lastPathComponent
     window?.title = "DraftFrame — \(dirName)"
+
+    if alreadyOpen { return }
 
     // Check for saved sessions to restore. QA runs skip the prompt and
     // always start fresh, without clearing the user's saved sessions.

--- a/Sources/DraftFrameKit/DFWindowController.swift
+++ b/Sources/DraftFrameKit/DFWindowController.swift
@@ -40,9 +40,10 @@ final class DFWindowController: NSWindowController {
     buildLayout()
     setupShortcuts()
 
-    // Prompt user to open a project directory
+    // Reopen where the user left off; prompt only when there's nothing
+    // to reopen.
     DispatchQueue.main.async { [weak self] in
-      self?.promptOpenProject()
+      self?.openInitialProject()
     }
   }
 
@@ -284,6 +285,28 @@ final class DFWindowController: NSWindowController {
 
   // MARK: - Open Project
 
+  /// Launch-time project selection: reopen the last workspace so quitting
+  /// and relaunching needs no manual re-setup. Falls back to the most
+  /// recently used project, then to the open panel. QA runs keep the old
+  /// prompt-first behavior — the QA script opens its own throwaway project
+  /// through the bridge, and must never land in the user's real one.
+  func openInitialProject() {
+    if QABridge.isQAMode {
+      promptOpenProject()
+      return
+    }
+    let fm = FileManager.default
+    if let last = SessionPersistence.shared.lastProjectDir, fm.fileExists(atPath: last) {
+      openProject(at: last, restoreWithoutAsking: true)
+      return
+    }
+    if let recent = ProjectManager.shared.projects.first?.path, fm.fileExists(atPath: recent) {
+      openProject(at: recent)
+      return
+    }
+    promptOpenProject()
+  }
+
   func promptOpenProject() {
     let panel = NSOpenPanel()
     panel.title = "Open Project"
@@ -306,7 +329,11 @@ final class DFWindowController: NSWindowController {
     }
   }
 
-  func openProject(at path: String) {
+  /// Open a project directory. With `restoreWithoutAsking` (the launch
+  /// path), saved sessions come back silently — the whole point of
+  /// persistence is that relaunching needs no clicks. A manual mid-session
+  /// open keeps the restore-or-fresh prompt.
+  func openProject(at path: String, restoreWithoutAsking: Bool = false) {
     // Set the project directory
     SessionManager.shared.projectDir = path
     FileManager.default.changeCurrentDirectoryPath(path)
@@ -331,23 +358,34 @@ final class DFWindowController: NSWindowController {
     }
     var shouldRestore = false
     if SessionPersistence.shared.hasSavedSessions(for: path) {
-      let alert = NSAlert()
-      alert.messageText = "Restore previous sessions?"
-      alert.informativeText =
-        "Saved sessions were found for this project. Would you like to restore them?"
-      alert.addButton(withTitle: "Restore")
-      alert.addButton(withTitle: "Start Fresh")
-      shouldRestore = alert.runModal() == .alertFirstButtonReturn
+      if restoreWithoutAsking {
+        shouldRestore = true
+      } else {
+        let alert = NSAlert()
+        alert.messageText = "Restore previous sessions?"
+        alert.informativeText =
+          "Saved sessions were found for this project. Would you like to restore them?"
+        alert.addButton(withTitle: "Restore")
+        alert.addButton(withTitle: "Start Fresh")
+        shouldRestore = alert.runModal() == .alertFirstButtonReturn
+      }
     }
 
     // Create sessions AFTER modal returns so the run loop is free
     DispatchQueue.main.async { [weak self] in
       if shouldRestore {
-        SessionPersistence.shared.restoreSessions(for: path)
+        // Every saved entry can be stale (worktrees removed, transcripts
+        // gone); if nothing comes back, fall through to a fresh session so
+        // the project never opens empty.
+        if !SessionPersistence.shared.restoreSessions(for: path) {
+          self?.terminalPane.createNewSession(name: dirName, worktreePath: path)
+        }
       } else {
         SessionPersistence.shared.clearSavedSessions()
         self?.terminalPane.createNewSession(name: dirName, worktreePath: path)
       }
+      // Safe to begin autosaving now that the saved state has been consumed.
+      SessionPersistence.shared.startAutoSave()
     }
   }
 

--- a/Sources/DraftFrameKit/QABridge.swift
+++ b/Sources/DraftFrameKit/QABridge.swift
@@ -278,6 +278,7 @@ import SwiftTerm
           "contextTokens": s.contextTokens,
           "maxContextTokens": s.maxContextTokens,
           "worktreePath": s.worktreePath ?? NSNull(),
+          "agentSessionId": s.agentSessionId ?? NSNull(),
           "active": i == mgr.activeSessionIndex,
         ]
       }

--- a/Sources/DraftFrameKit/SessionJSONLWatcher.swift
+++ b/Sources/DraftFrameKit/SessionJSONLWatcher.swift
@@ -90,6 +90,17 @@ final class SessionJSONLWatcher: @unchecked Sendable {
   var agentSessionId: String? { assistantTextLock.withLock { _agentSessionId } }
   private var _agentSessionId: String?
 
+  /// Gate on the id capture: the watcher tails whatever transcript in the
+  /// shared per-cwd folder is newest, which for a fresh tab in a directory
+  /// with prior history is some EARLIER run's conversation. Persisting that
+  /// id would make the tab resume a conversation it never had, so ids are
+  /// trusted only from a transcript written during this watcher's lifetime.
+  /// Maintained by `findLatestJSONL` and read by `parseLine`, both on the
+  /// tailer's queue. Internal (and defaulting to true) for direct
+  /// `parseLine` tests.
+  var captureSessionIds = true
+  private let watcherStartedAt = Date()
+
   // MARK: - Private
 
   private let onUpdate: UpdateCallback
@@ -193,6 +204,13 @@ final class SessionJSONLWatcher: @unchecked Sendable {
         newest = full
       }
     }
+    if newest != nil {
+      // A transcript untouched since before this watcher existed belongs to
+      // an earlier run: read it for usage/cost as always, but don't let its
+      // session id be persisted as this tab's conversation. Re-evaluated on
+      // every rescan, so the flag flips on as soon as the agent writes.
+      captureSessionIds = newestDate >= watcherStartedAt
+    }
     return newest
   }
 
@@ -241,8 +259,9 @@ final class SessionJSONLWatcher: @unchecked Sendable {
       let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
     else { return false }
     // Every transcript line carries the session id, including types the
-    // switch below ignores — capture it before dispatching.
-    if let sid = obj["sessionId"] as? String, !sid.isEmpty {
+    // switch below ignores — capture it before dispatching (unless the
+    // watched file predates this watcher; see `captureSessionIds`).
+    if captureSessionIds, let sid = obj["sessionId"] as? String, !sid.isEmpty {
       assistantTextLock.withLock { _agentSessionId = sid }
     }
     guard let type = obj["type"] as? String else { return false }

--- a/Sources/DraftFrameKit/SessionJSONLWatcher.swift
+++ b/Sources/DraftFrameKit/SessionJSONLWatcher.swift
@@ -83,6 +83,13 @@ final class SessionJSONLWatcher: @unchecked Sendable {
   private var _latestAssistantText: String?
   private var _latestAssistantAt: Date?
 
+  /// Claude Code's own session id, read from the transcript's `sessionId`
+  /// field. This is what `claude --resume` takes, so it's what session
+  /// persistence saves. Same cross-thread access pattern as the assistant
+  /// text: written on the tailer's queue, read from the main thread.
+  var agentSessionId: String? { assistantTextLock.withLock { _agentSessionId } }
+  private var _agentSessionId: String?
+
   // MARK: - Private
 
   private let onUpdate: UpdateCallback
@@ -135,6 +142,10 @@ final class SessionJSONLWatcher: @unchecked Sendable {
   }
 
   private func claudeProjectDir() -> String? {
+    Self.claudeProjectDir(forWorkingDirectory: workingDirectory)
+  }
+
+  static func claudeProjectDir(forWorkingDirectory workingDirectory: String) -> String? {
     let home = FileManager.default.homeDirectoryForCurrentUser.path
     // Claude Code encodes its own getcwd — the symlink-RESOLVED path
     // (/private/tmp, not /tmp) — while the session may hold the unresolved
@@ -155,6 +166,13 @@ final class SessionJSONLWatcher: @unchecked Sendable {
       }
     }
     return nil
+  }
+
+  /// Whether Claude Code still has a transcript for `sessionId` launched from
+  /// `workingDirectory` — the precondition for `claude --resume <sessionId>`.
+  static func transcriptExists(sessionId: String, workingDirectory: String) -> Bool {
+    guard let dir = claudeProjectDir(forWorkingDirectory: workingDirectory) else { return false }
+    return FileManager.default.fileExists(atPath: "\(dir)/\(sessionId).jsonl")
   }
 
   private func findLatestJSONL() -> String? {
@@ -220,9 +238,14 @@ final class SessionJSONLWatcher: @unchecked Sendable {
   /// advanced. Internal for testing.
   func parseLine(_ line: String) -> Bool {
     guard let data = line.data(using: .utf8),
-      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let type = obj["type"] as? String
+      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
     else { return false }
+    // Every transcript line carries the session id, including types the
+    // switch below ignores — capture it before dispatching.
+    if let sid = obj["sessionId"] as? String, !sid.isEmpty {
+      assistantTextLock.withLock { _agentSessionId = sid }
+    }
+    guard let type = obj["type"] as? String else { return false }
     switch type {
     case "assistant": return parseAssistant(obj)
     case "user": return parseUser(obj)

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -548,6 +548,11 @@ final class SessionManager {
       })
     else { return }
     session.name = newName
+    // Carry the resume id across the watcher swap: the replacement watcher
+    // starts blank, and the autosave triggered by the list change below
+    // would otherwise persist nil for this session. Read before
+    // stopWatchers() while the old watcher still holds the id.
+    session.resumedFromSessionId = session.agentSessionId
     session.worktreePath = newPath
     session.stopWatchers()
     session.startWatchers(directory: newPath)

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -139,6 +139,16 @@ final class Session {
   /// rollout JSONL) for cost/token updates.
   var usageWatcher: UsageWatcher?
 
+  /// The agent CLI's own session id, once the transcript watcher has seen
+  /// it. Saved across app restarts so the session can relaunch with
+  /// `claude --resume` instead of starting a fresh conversation. Until the
+  /// watcher has read a transcript, falls back to the id this session was
+  /// itself resumed from, so back-to-back restarts don't lose the thread.
+  var agentSessionId: String? { usageWatcher?.agentSessionId ?? resumedFromSessionId }
+
+  /// The id passed to `--resume` when this session was restored, if any.
+  var resumedFromSessionId: String?
+
   /// Watches `~/.claude/sessions/<pid>.json` for authoritative session state.
   /// Claude sessions only — Codex has no equivalent, so its state comes from
   /// the PTY stream analyzer instead.
@@ -374,10 +384,12 @@ final class SessionManager {
   /// with the agent it originally launched with. `initialPrompt` is handed
   /// to the agent CLI as a positional argument so the session starts working
   /// on it immediately (used for ticket-linked worktrees).
+  /// `resumeSessionId` relaunches the agent into a previous conversation
+  /// (`claude --resume`) — used when restoring saved sessions.
   @discardableResult
   func createSession(
     name: String? = nil, command: String? = nil, worktreePath: String? = nil,
-    agent: AgentKind? = nil, initialPrompt: String? = nil
+    agent: AgentKind? = nil, initialPrompt: String? = nil, resumeSessionId: String? = nil
   )
     -> Session
   {
@@ -388,6 +400,7 @@ final class SessionManager {
     let sessionName = name ?? "session-\(sessions.count + 1)"
     let session = Session(
       name: sessionName, worktreePath: worktreePath, agent: agent, launchModelId: modelId)
+    session.resumedFromSessionId = resumeSessionId
 
     // Create the terminal view (ClaudeTerminalView intercepts PTY data).
     // Use a zero frame — autolayout will resize to the real visible area
@@ -450,7 +463,8 @@ final class SessionManager {
     // on the spawned login shell re-sourcing PATH correctly.
     let agentBin = SessionManager.resolveAgentPath(agent: agent, augmentedPath: composedPath)
     let agentCmd = agent.launchCommand(
-      binPath: agentBin, modelId: modelId, initialPrompt: initialPrompt)
+      binPath: agentBin, modelId: modelId, initialPrompt: initialPrompt,
+      resumeSessionId: resumeSessionId)
 
     // Start transcript/status watchers for cost/token/state tracking.
     let watchDir = worktreePath ?? projectDir ?? FileManager.default.currentDirectoryPath

--- a/Sources/DraftFrameKit/SessionPersistence.swift
+++ b/Sources/DraftFrameKit/SessionPersistence.swift
@@ -1,7 +1,11 @@
 import Foundation
 
-/// Saves and restores session names and worktree paths across app launches.
-/// Persists to ~/.config/draftframe/sessions.json.
+/// Saves and restores the working state — open project, sessions, and their
+/// Claude session ids — across app launches. Persists to
+/// ~/.config/draftframe/sessions.json. State is written on quit and
+/// periodically while running (so a crash loses at most one interval), and
+/// restored sessions relaunch with `claude --resume` when the original
+/// conversation's transcript still exists.
 /// Main-actor isolated: reads and mutates SessionManager state.
 @MainActor
 final class SessionPersistence {
@@ -9,6 +13,12 @@ final class SessionPersistence {
 
   private static let configDir = NSHomeDirectory() + "/.config/draftframe"
   private static let sessionsPath = configDir + "/sessions.json"
+
+  /// How often the running state is snapshotted to disk between the
+  /// event-driven saves. Only exists to bound crash loss.
+  private static let autoSaveInterval: TimeInterval = 30
+
+  private var autoSaveTimer: Timer?
 
   private init() {}
 
@@ -20,29 +30,48 @@ final class SessionPersistence {
     /// AgentKind raw value. Optional so files written before agent support
     /// still decode; those sessions were always Claude.
     let agent: String?
+    /// The agent CLI's own session id (what `claude --resume` takes).
+    /// Optional: unknown until the agent writes its transcript, and absent
+    /// in files written by older app versions.
+    let agentSessionId: String?
   }
 
   struct SessionsFile: Codable {
     let projectDir: String
     let sessions: [SavedSession]
+    /// Which session was selected at save time. Optional for old files.
+    let activeSessionIndex: Int?
   }
 
   // MARK: - Save
 
-  /// Save current sessions to disk. Call before quitting.
+  /// Save current sessions to disk. Called on quit and by the autosave
+  /// timer/observer. An empty session list clears the file — restoring
+  /// sessions the user deliberately closed would be worse than nothing.
   func saveSessions() {
-    let sessions = SessionManager.shared.sessions
-    guard !sessions.isEmpty else { return }
+    // QA runs share this file with real launches; never let their throwaway
+    // sessions overwrite the user's real saved state.
+    if QABridge.isQAMode { return }
+    // Nothing open yet (startup, before a project is chosen) — don't touch
+    // the saved state the launch flow is about to restore.
+    guard let projectDir = SessionManager.shared.projectDir else { return }
 
-    let projectDir = SessionManager.shared.projectDir ?? FileManager.default.currentDirectoryPath
+    let sessions = SessionManager.shared.sessions
+    guard !sessions.isEmpty else {
+      clearSavedSessions()
+      return
+    }
 
     let saved = sessions.map { session in
       SavedSession(
         name: session.name, worktreePath: session.worktreePath,
-        agent: session.agent.rawValue)
+        agent: session.agent.rawValue,
+        agentSessionId: session.agentSessionId)
     }
 
-    let file = SessionsFile(projectDir: projectDir, sessions: saved)
+    let file = SessionsFile(
+      projectDir: projectDir, sessions: saved,
+      activeSessionIndex: SessionManager.shared.activeSessionIndex)
 
     let fm = FileManager.default
     let dir = SessionPersistence.configDir
@@ -58,7 +87,42 @@ final class SessionPersistence {
     }
   }
 
+  /// Begin saving state periodically and on session-list changes, so a crash
+  /// or force-quit loses at most `autoSaveInterval` of state. Idempotent;
+  /// started once the initial project is open (starting earlier would let a
+  /// save of the empty startup state clear the file before restore runs).
+  func startAutoSave() {
+    guard autoSaveTimer == nil, !QABridge.isQAMode else { return }
+
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(sessionListChanged),
+      name: .sessionListDidChange, object: nil)
+
+    let timer = Timer.scheduledTimer(
+      withTimeInterval: Self.autoSaveInterval, repeats: true
+    ) { _ in
+      // The timer fires on the main run loop; the hop makes that
+      // main-actor guarantee explicit for the compiler.
+      DispatchQueue.main.async {
+        SessionPersistence.shared.saveSessions()
+      }
+    }
+    timer.tolerance = 5
+    autoSaveTimer = timer
+  }
+
+  @objc private func sessionListChanged() {
+    saveSessions()
+  }
+
   // MARK: - Restore
+
+  /// The project directory the last saved state belongs to, or nil when
+  /// there is no saved state. Used at launch to reopen where the user
+  /// left off.
+  var lastProjectDir: String? {
+    loadSessionsFile()?.projectDir
+  }
 
   /// Check if there are saved sessions for the given project directory.
   func hasSavedSessions(for projectDir: String) -> Bool {
@@ -73,11 +137,16 @@ final class SessionPersistence {
     return file.sessions
   }
 
-  /// Restore saved sessions by creating them in SessionManager.
-  func restoreSessions(for projectDir: String) {
-    guard let saved = loadSavedSessions(for: projectDir) else { return }
+  /// Restore saved sessions by creating them in SessionManager, resuming
+  /// each Claude conversation whose transcript still exists. Returns whether
+  /// any session was restored, so the caller can fall back to a fresh one.
+  @discardableResult
+  func restoreSessions(for projectDir: String) -> Bool {
+    guard let file = loadSessionsFile(),
+      file.projectDir == projectDir, !file.sessions.isEmpty
+    else { return false }
 
-    for entry in saved {
+    for entry in file.sessions {
       // Verify worktree path still exists if specified
       var wtPath = entry.worktreePath
       if let path = wtPath, !FileManager.default.fileExists(atPath: path) {
@@ -85,12 +154,35 @@ final class SessionPersistence {
       }
 
       let agent = entry.agent.flatMap(AgentKind.init(rawValue:)) ?? .claude
+      let workDir = wtPath ?? projectDir
+
+      // Resume the previous conversation only when its transcript is still
+      // on disk for the directory the session will actually launch in —
+      // `claude --resume` with a stale id fails outright, which would leave
+      // the restored tab sitting on an error.
+      var resumeId: String?
+      if agent == .claude, let sid = entry.agentSessionId,
+        SessionJSONLWatcher.transcriptExists(sessionId: sid, workingDirectory: workDir)
+      {
+        resumeId = sid
+      }
+
       SessionManager.shared.createSession(
-        name: entry.name, worktreePath: wtPath ?? projectDir, agent: agent)
+        name: entry.name, worktreePath: workDir, agent: agent,
+        resumeSessionId: resumeId)
     }
 
-    // Clear the saved file after restoring
-    clearSavedSessions()
+    // Reselect the session that was active at save time.
+    let count = SessionManager.shared.sessions.count
+    if let idx = file.activeSessionIndex, idx >= 0, idx < count {
+      SessionManager.shared.switchTo(index: idx)
+    }
+
+    // Rewrite the file from the live state (each restored session keeps its
+    // resume id via `resumedFromSessionId`), so a crash right after restore
+    // still finds the same workspace next launch.
+    saveSessions()
+    return true
   }
 
   /// Remove the saved sessions file.

--- a/Sources/DraftFrameKit/SessionPersistence.swift
+++ b/Sources/DraftFrameKit/SessionPersistence.swift
@@ -62,12 +62,13 @@ final class SessionPersistence {
       return
     }
 
-    let saved = sessions.map { session in
-      SavedSession(
-        name: session.name, worktreePath: session.worktreePath,
-        agent: session.agent.rawValue,
-        agentSessionId: session.agentSessionId)
-    }
+    let saved = Self.dedupingResumeIds(
+      sessions.map { session in
+        SavedSession(
+          name: session.name, worktreePath: session.worktreePath,
+          agent: session.agent.rawValue,
+          agentSessionId: session.agentSessionId)
+      })
 
     let file = SessionsFile(
       projectDir: projectDir, sessions: saved,
@@ -115,6 +116,19 @@ final class SessionPersistence {
     saveSessions()
   }
 
+  /// Drop duplicate resume ids, keeping the first occurrence. Two tabs
+  /// sharing a working directory can converge on the same newest transcript;
+  /// resuming one conversation from two sessions would put two claude
+  /// processes on one transcript, so later duplicates restore fresh instead.
+  nonisolated static func dedupingResumeIds(_ sessions: [SavedSession]) -> [SavedSession] {
+    var seen = Set<String>()
+    return sessions.map { s in
+      guard let id = s.agentSessionId, !seen.insert(id).inserted else { return s }
+      return SavedSession(
+        name: s.name, worktreePath: s.worktreePath, agent: s.agent, agentSessionId: nil)
+    }
+  }
+
   // MARK: - Restore
 
   /// The project directory the last saved state belongs to, or nil when
@@ -146,6 +160,16 @@ final class SessionPersistence {
       file.projectDir == projectDir, !file.sessions.isEmpty
     else { return false }
 
+    // The saved active index is relative to the saved list; sessions may
+    // already exist (another project's tabs), so offset by where the
+    // restored block begins.
+    let firstRestoredIndex = SessionManager.shared.sessions.count
+    // Never hand the same conversation to two sessions — two claude
+    // processes appending to one transcript corrupt it. Files written by
+    // current code are already deduped at save time; this covers older or
+    // hand-edited files.
+    var usedResumeIds = Set<String>()
+
     for entry in file.sessions {
       // Verify worktree path still exists if specified
       var wtPath = entry.worktreePath
@@ -161,10 +185,11 @@ final class SessionPersistence {
       // `claude --resume` with a stale id fails outright, which would leave
       // the restored tab sitting on an error.
       var resumeId: String?
-      if agent == .claude, let sid = entry.agentSessionId,
+      if agent == .claude, let sid = entry.agentSessionId, !usedResumeIds.contains(sid),
         SessionJSONLWatcher.transcriptExists(sessionId: sid, workingDirectory: workDir)
       {
         resumeId = sid
+        usedResumeIds.insert(sid)
       }
 
       SessionManager.shared.createSession(
@@ -174,8 +199,8 @@ final class SessionPersistence {
 
     // Reselect the session that was active at save time.
     let count = SessionManager.shared.sessions.count
-    if let idx = file.activeSessionIndex, idx >= 0, idx < count {
-      SessionManager.shared.switchTo(index: idx)
+    if let idx = file.activeSessionIndex, idx >= 0, firstRestoredIndex + idx < count {
+      SessionManager.shared.switchTo(index: firstRestoredIndex + idx)
     }
 
     // Rewrite the file from the live state (each restored session keeps its

--- a/Tests/DraftFrameTests/SessionPersistenceTests.swift
+++ b/Tests/DraftFrameTests/SessionPersistenceTests.swift
@@ -34,7 +34,9 @@ final class SessionPersistenceTests: XCTestCase {
   // MARK: - Session id capture from the transcript
 
   func testWatcherCapturesSessionIdFromAnyLineType() {
-    let watcher = SessionJSONLWatcher(workingDirectory: "/nonexistent") { _, _, _, _, _, _, _, _, _ in }
+    let watcher = SessionJSONLWatcher(workingDirectory: "/nonexistent") {
+      _, _, _, _, _, _, _, _, _ in
+    }
     defer { watcher.stop() }
     XCTAssertNil(watcher.agentSessionId)
 
@@ -45,7 +47,8 @@ final class SessionPersistenceTests: XCTestCase {
 
     // A newer line (e.g. after the tailer switches files) replaces it.
     _ = watcher.parseLine(
-      #"{"type":"user","sessionId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","message":{"content":"hi"}}"#)
+      #"{"type":"user","sessionId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","message":{"content":"hi"}}"#
+    )
     XCTAssertEqual(watcher.agentSessionId, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
     // Lines without the field leave the last-seen id in place.

--- a/Tests/DraftFrameTests/SessionPersistenceTests.swift
+++ b/Tests/DraftFrameTests/SessionPersistenceTests.swift
@@ -56,6 +56,43 @@ final class SessionPersistenceTests: XCTestCase {
     XCTAssertEqual(watcher.agentSessionId, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
   }
 
+  func testWatcherIgnoresSessionIdWhenCaptureDisabled() {
+    let watcher = SessionJSONLWatcher(workingDirectory: "/nonexistent") {
+      _, _, _, _, _, _, _, _, _ in
+    }
+    defer { watcher.stop() }
+
+    watcher.captureSessionIds = false
+    _ = watcher.parseLine(
+      #"{"type":"summary","sessionId":"11111111-2222-3333-4444-555555555555"}"#)
+    XCTAssertNil(watcher.agentSessionId)
+
+    watcher.captureSessionIds = true
+    _ = watcher.parseLine(
+      #"{"type":"summary","sessionId":"11111111-2222-3333-4444-555555555555"}"#)
+    XCTAssertEqual(watcher.agentSessionId, "11111111-2222-3333-4444-555555555555")
+  }
+
+  // MARK: - Resume id dedup
+
+  func testDedupingResumeIdsKeepsFirstOccurrence() {
+    let sessions = [
+      SessionPersistence.SavedSession(
+        name: "a", worktreePath: "/p", agent: "claude", agentSessionId: "id-1"),
+      SessionPersistence.SavedSession(
+        name: "b", worktreePath: "/p", agent: "claude", agentSessionId: "id-1"),
+      SessionPersistence.SavedSession(
+        name: "c", worktreePath: "/q", agent: "claude", agentSessionId: "id-2"),
+      SessionPersistence.SavedSession(
+        name: "d", worktreePath: "/r", agent: "claude", agentSessionId: nil),
+    ]
+    let deduped = SessionPersistence.dedupingResumeIds(sessions)
+    XCTAssertEqual(deduped.map { $0.agentSessionId }, ["id-1", nil, "id-2", nil])
+    // Everything else survives untouched.
+    XCTAssertEqual(deduped.map { $0.name }, ["a", "b", "c", "d"])
+    XCTAssertEqual(deduped[1].worktreePath, "/p")
+  }
+
   // MARK: - Saved-file format compatibility
 
   func testDecodesFileWrittenByOlderVersions() throws {

--- a/Tests/DraftFrameTests/SessionPersistenceTests.swift
+++ b/Tests/DraftFrameTests/SessionPersistenceTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+final class SessionPersistenceTests: XCTestCase {
+
+  // MARK: - Resume launch command
+
+  func testClaudeLaunchCommandWithResume() {
+    let cmd = AgentKind.claude.launchCommand(
+      binPath: "/opt/homebrew/bin/claude", modelId: "",
+      resumeSessionId: "72edbe87-6e8e-4ef2-b7c2-11b8633c2bef")
+    XCTAssertEqual(
+      cmd, "/opt/homebrew/bin/claude --resume '72edbe87-6e8e-4ef2-b7c2-11b8633c2bef'")
+  }
+
+  func testClaudeLaunchCommandWithResumeAndModel() {
+    let cmd = AgentKind.claude.launchCommand(
+      binPath: "claude", modelId: "claude-opus-4-8", resumeSessionId: "abc")
+    XCTAssertEqual(cmd, "claude --model claude-opus-4-8 --resume 'abc'")
+  }
+
+  func testCodexLaunchCommandIgnoresResume() {
+    let cmd = AgentKind.codex.launchCommand(
+      binPath: "codex", modelId: "", resumeSessionId: "abc")
+    XCTAssertEqual(cmd, "codex")
+  }
+
+  func testLaunchCommandWithoutResumeUnchanged() {
+    let cmd = AgentKind.claude.launchCommand(binPath: "claude", modelId: "")
+    XCTAssertEqual(cmd, "claude")
+  }
+
+  // MARK: - Session id capture from the transcript
+
+  func testWatcherCapturesSessionIdFromAnyLineType() {
+    let watcher = SessionJSONLWatcher(workingDirectory: "/nonexistent") { _, _, _, _, _, _, _, _, _ in }
+    defer { watcher.stop() }
+    XCTAssertNil(watcher.agentSessionId)
+
+    // Lines whose type the usage parser ignores still carry the id.
+    _ = watcher.parseLine(
+      #"{"type":"summary","sessionId":"11111111-2222-3333-4444-555555555555"}"#)
+    XCTAssertEqual(watcher.agentSessionId, "11111111-2222-3333-4444-555555555555")
+
+    // A newer line (e.g. after the tailer switches files) replaces it.
+    _ = watcher.parseLine(
+      #"{"type":"user","sessionId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","message":{"content":"hi"}}"#)
+    XCTAssertEqual(watcher.agentSessionId, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    // Lines without the field leave the last-seen id in place.
+    _ = watcher.parseLine(#"{"type":"user","message":{"content":"hi"}}"#)
+    XCTAssertEqual(watcher.agentSessionId, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+  }
+
+  // MARK: - Saved-file format compatibility
+
+  func testDecodesFileWrittenByOlderVersions() throws {
+    // Files from before resume support carry neither agentSessionId nor
+    // activeSessionIndex; they must still decode.
+    let json = """
+      {
+        "projectDir": "/Users/x/proj",
+        "sessions": [
+          {"name": "main", "worktreePath": null, "agent": "claude"}
+        ]
+      }
+      """
+    let file = try JSONDecoder().decode(
+      SessionPersistence.SessionsFile.self, from: Data(json.utf8))
+    XCTAssertEqual(file.projectDir, "/Users/x/proj")
+    XCTAssertEqual(file.sessions.count, 1)
+    XCTAssertNil(file.sessions[0].agentSessionId)
+    XCTAssertNil(file.activeSessionIndex)
+  }
+
+  func testRoundTripsResumeState() throws {
+    let file = SessionPersistence.SessionsFile(
+      projectDir: "/p",
+      sessions: [
+        SessionPersistence.SavedSession(
+          name: "feature", worktreePath: "/p/.claude/worktrees/feature",
+          agent: "claude", agentSessionId: "abc-123")
+      ],
+      activeSessionIndex: 0)
+    let data = try JSONEncoder().encode(file)
+    let decoded = try JSONDecoder().decode(SessionPersistence.SessionsFile.self, from: data)
+    XCTAssertEqual(decoded.sessions[0].agentSessionId, "abc-123")
+    XCTAssertEqual(decoded.activeSessionIndex, 0)
+  }
+
+  func testTranscriptExistsIsFalseForUnknownDirectory() {
+    XCTAssertFalse(
+      SessionJSONLWatcher.transcriptExists(
+        sessionId: "no-such-id", workingDirectory: "/nonexistent/dir/for/tests"))
+  }
+}


### PR DESCRIPTION
Closes #22

## What

Quitting and relaunching DraftFrame now brings back the previous workspace with no manual re-setup: the last project reopens, its session tabs come back, and each Claude session resumes its previous conversation via `claude --resume <session-id>` instead of starting fresh.

## How

- **Session id capture**: `SessionJSONLWatcher` reads Claude Code's own session id from the transcript's `sessionId` field (present on every line) and exposes it through the `UsageWatcher` protocol. Codex returns nil, so Codex sessions restore fresh.
- **Richer saved state**: `SessionPersistence` now stores each session's `agentSessionId` and the active tab index alongside name/worktree/agent. Old `sessions.json` files still decode (new fields are optional).
- **Resume on restore**: `AgentKind.launchCommand` gains a `resumeSessionId` parameter; restore passes it only when the transcript file still exists for the directory the session will launch in, so a stale id falls back to a fresh launch instead of wedging the tab on a resume error. A missing worktree falls back to the project root, as before.
- **Auto-reopen at launch**: `openInitialProject()` reopens the last saved project (falling back to the most recent sidebar project, then the open panel) and restores its sessions silently. The restore-or-fresh alert now only appears for manual mid-session project opens.
- **Crash resilience**: state is autosaved on every session-list change plus a 30s timer, starting only after the initial restore has consumed the saved file. Closing all sessions clears the file so deliberately closed sessions don't resurrect. Restored sessions are seeded with the id they resumed from, so a crash right after restore loses nothing.
- **QA mode** stays fully excluded from persistence and the auto-reopen path; the QA sessions output now includes `agentSessionId` for verification.

## Testing

- 144/144 tests pass, including 7 new ones covering resume command construction, session-id capture from transcript lines, old-format file decoding, and round-tripping.
- QA smoke test: launched the app under the bridge, opened a scratch project, confirmed the watcher captured the real session id after one message, then ran `claude --resume <captured-id>` headlessly from that directory and confirmed it recalled the earlier conversation.
- Remaining manual check (QA mode is excluded from persistence by design): open a project, run a session or two, quit, relaunch, and confirm the same tabs come back with their conversations resumed.