### PR TITLE
Remove worktrees with merged PRs from the project context menu

### DIFF
--- a/Sources/DraftFrameKit/DFSidebar.swift
+++ b/Sources/DraftFrameKit/DFSidebar.swift
@@ -29,6 +29,19 @@ final class DFSidebar: NSView {
   /// while its path is in here. Main-thread only.
   private var worktreeSetupsInFlight: Set<String> = []
 
+  /// Project paths with a merged-worktree sweep running, mapped to the
+  /// status shown in the row ("Scanning…", "Removing 3 of 12…"). The row's
+  /// broom is replaced by a spinner plus that text while its path is in
+  /// here. Part of the section snapshot so the row rebuilds as it changes.
+  /// Main-thread only.
+  private var sweepsInFlight: [String: String] = [:]
+  /// True only while a sweep is actually removing worktrees. Worktree-list
+  /// refreshes are deferred (see `refreshWorktrees`) so each closed session
+  /// and removed directory doesn't re-render the sidebar mid-sweep.
+  private var sweepRemovalPhase = false
+  /// Set when a refresh arrived during the removal phase; replayed after.
+  private var sweepDeferredRefresh = false
+
   /// Composed SF Symbol: leaf with a small "+" badge in the bottom-right.
   private static let leafPlusBadge: NSImage = {
     let size = NSSize(width: 16, height: 16)
@@ -82,6 +95,7 @@ final class DFSidebar: NSView {
     let isActive: Bool
     let isPulling: Bool
     let isSettingUp: Bool
+    let sweepStatus: String?
     let worktrees: [WorktreeKey]
   }
   private struct WorktreeKey: Equatable {
@@ -444,6 +458,12 @@ final class DFSidebar: NSView {
   private var lastEnumerated: [String: [WorktreeManager.Worktree]]?
 
   @objc func refreshWorktrees() {
+    // Mid-sweep, each closed session and removed worktree would otherwise
+    // trigger a rebuild; hold them until the sweep's summary lands.
+    if sweepRemovalPhase {
+      sweepDeferredRefresh = true
+      return
+    }
     // Repaint synchronously from cached listings first — sort, collapse, and
     // selection changes must land this frame to feel instant. The background
     // enumeration below then re-applies only if git reports something
@@ -518,6 +538,7 @@ final class DFSidebar: NSView {
         isActive: project.path == activeDir,
         isPulling: pullsInFlight.contains(project.path),
         isSettingUp: worktreeSetupsInFlight.contains(project.path),
+        sweepStatus: sweepsInFlight[project.path],
         worktrees: (worktreesPerProject[project.path] ?? []).map {
           WorktreeKey(path: $0.path, branch: $0.branch, isBare: $0.isBare)
         })
@@ -661,13 +682,39 @@ final class DFSidebar: NSView {
       addBtn.heightAnchor.constraint(equalToConstant: 16),
     ])
 
+    // While a merged-PR sweep (context menu) runs for this project, show a
+    // spinner and its progress text next to the add button.
+    var trailingControl: NSView = addBtn
+    if let status = sweepsInFlight[project.path] {
+      let spinner = NSProgressIndicator()
+      spinner.style = .spinning
+      spinner.controlSize = .small
+      spinner.isIndeterminate = true
+      spinner.isDisplayedWhenStopped = false
+      spinner.startAnimation(nil)
+      spinner.translatesAutoresizingMaskIntoConstraints = false
+      projectRow.addSubview(spinner)
+      let statusLabel = label(status, size: 9, color: Theme.text3)
+      statusLabel.translatesAutoresizingMaskIntoConstraints = false
+      projectRow.addSubview(statusLabel)
+      NSLayoutConstraint.activate([
+        spinner.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
+        spinner.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
+        spinner.widthAnchor.constraint(equalToConstant: 16),
+        spinner.heightAnchor.constraint(equalToConstant: 16),
+        statusLabel.trailingAnchor.constraint(equalTo: spinner.leadingAnchor, constant: -4),
+        statusLabel.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
+      ])
+      trailingControl = statusLabel
+    }
+
     // While a background default-branch pull or a worktree setup
     // (base-branch pull + create) runs for this project, show a spinner
     // next to the add button. Both sets are part of the snapshot, so the
     // row rebuilds when either changes.
     let isPulling = pullsInFlight.contains(project.path)
-    var trailingControl: NSView = addBtn
     if isPulling || worktreeSetupsInFlight.contains(project.path) {
+      let anchorView = trailingControl
       let spinner = NSProgressIndicator()
       spinner.style = .spinning
       spinner.controlSize = .small
@@ -677,7 +724,7 @@ final class DFSidebar: NSView {
       spinner.translatesAutoresizingMaskIntoConstraints = false
       projectRow.addSubview(spinner)
       NSLayoutConstraint.activate([
-        spinner.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
+        spinner.trailingAnchor.constraint(equalTo: anchorView.leadingAnchor, constant: -6),
         spinner.centerYAnchor.constraint(equalTo: projectRow.centerYAnchor),
         spinner.widthAnchor.constraint(equalToConstant: 16),
         spinner.heightAnchor.constraint(equalToConstant: 16),
@@ -731,6 +778,14 @@ final class DFSidebar: NSView {
     fromBranchItem.target = self
     fromBranchItem.representedObject = project.path
     menu.addItem(fromBranchItem)
+
+    menu.addItem(NSMenuItem.separator())
+    let sweepItem = NSMenuItem(
+      title: "Remove Merged Workspaces…",
+      action: #selector(sweepProjectFromMenu(_:)), keyEquivalent: "")
+    sweepItem.target = self
+    sweepItem.representedObject = project.path
+    menu.addItem(sweepItem)
 
     menu.addItem(NSMenuItem.separator())
     let removeItem = NSMenuItem(
@@ -941,6 +996,177 @@ final class DFSidebar: NSView {
           self.refreshWorktrees()
         }
       }
+    }
+  }
+
+  // MARK: - Sweep merged worktrees
+
+  @objc private func sweepProjectFromMenu(_ sender: NSMenuItem) {
+    guard let repoRoot = sender.representedObject as? String, !repoRoot.isEmpty,
+      sweepsInFlight[repoRoot] == nil
+    else { return }
+    let projectName = (repoRoot as NSString).lastPathComponent
+    setSweepStatus("Scanning…", for: repoRoot)
+
+    WorktreeSweeper.shared.scan(repoRoot: repoRoot) { [weak self] candidates in
+      guard let self = self else { return }
+      if candidates.isEmpty {
+        self.setSweepStatus(nil, for: repoRoot)
+        self.showInfoSheet(
+          title: "Nothing to Remove",
+          body: "No workspaces in \(projectName) have a merged pull request.")
+        return
+      }
+      // Keep the row busy behind the sheet so a second click can't start a
+      // parallel sweep of the same repo.
+      self.setSweepStatus("Confirm…", for: repoRoot)
+      self.confirmSweep(projectName: projectName, candidates: candidates) { selected in
+        guard !selected.isEmpty else {
+          self.setSweepStatus(nil, for: repoRoot)
+          return
+        }
+        self.runSweep(repoRoot: repoRoot, candidates: selected)
+      }
+    }
+  }
+
+  /// Confirmation sheet listing every candidate with a checkbox (all checked
+  /// by default). Calls `completion` with the checked subset, or an empty
+  /// array on cancel.
+  private func confirmSweep(
+    projectName: String, candidates: [SweepCandidate],
+    completion: @escaping ([SweepCandidate]) -> Void
+  ) {
+    guard let win = window else {
+      completion([])
+      return
+    }
+    let alert = NSAlert()
+    alert.messageText = "Remove Workspaces with Merged PRs in \(projectName)?"
+    alert.informativeText =
+      "These workspaces have merged pull requests. Checked workspaces will be removed, "
+      + "along with any sessions open on them. Uncommitted changes in them will be lost."
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: "Remove")
+    alert.addButton(withTitle: "Cancel")
+
+    let list = NSStackView()
+    list.orientation = .vertical
+    list.alignment = .leading
+    list.spacing = 4
+    list.translatesAutoresizingMaskIntoConstraints = false
+    var checkboxes: [NSButton] = []
+    for candidate in candidates {
+      let branch =
+        candidate.worktree.branch == candidate.name ? "" : "  (\(candidate.worktree.branch))"
+      let box = NSButton(
+        checkboxWithTitle: "\(candidate.name)\(branch)  PR #\(candidate.prNumber)",
+        target: nil, action: nil)
+      box.state = .on
+      box.font = NSFont.systemFont(ofSize: 12)
+      box.lineBreakMode = .byTruncatingMiddle
+      list.addArrangedSubview(box)
+      checkboxes.append(box)
+    }
+
+    // Scroll once the list would push the sheet past a sane height.
+    let rowHeight: CGFloat = 22
+    let visibleRows = min(candidates.count, 12)
+    let scroll = NSScrollView(
+      frame: NSRect(x: 0, y: 0, width: 420, height: CGFloat(visibleRows) * rowHeight + 4))
+    scroll.hasVerticalScroller = candidates.count > visibleRows
+    scroll.drawsBackground = false
+    scroll.borderType = .noBorder
+    let doc = FlippedView(
+      frame: NSRect(x: 0, y: 0, width: 400, height: CGFloat(candidates.count) * rowHeight))
+    doc.addSubview(list)
+    NSLayoutConstraint.activate([
+      list.topAnchor.constraint(equalTo: doc.topAnchor),
+      list.leadingAnchor.constraint(equalTo: doc.leadingAnchor),
+      list.widthAnchor.constraint(equalTo: doc.widthAnchor),
+    ])
+    scroll.documentView = doc
+    alert.accessoryView = scroll
+
+    alert.beginSheetModal(for: win) { response in
+      guard response == .alertFirstButtonReturn else {
+        completion([])
+        return
+      }
+      let selected = zip(candidates, checkboxes)
+        .filter { $0.1.state == .on }
+        .map { $0.0 }
+      completion(selected)
+    }
+  }
+
+  private func runSweep(repoRoot: String, candidates: [SweepCandidate]) {
+    // Hide the doomed rows right away (painted from cache this frame), then
+    // freeze the list for the duration of the removals.
+    for c in candidates { pendingRemovals.insert(c.worktree.path) }
+    setSweepStatus("Removing 1 of \(candidates.count)…", for: repoRoot)
+    sweepRemovalPhase = true
+
+    WorktreeSweeper.shared.sweep(
+      repoRoot: repoRoot, candidates: candidates,
+      progress: { [weak self] index, total in
+        guard let self = self else { return }
+        // Bypass the refresh guard: repaint just this row from cache.
+        self.sweepsInFlight[repoRoot] = "Removing \(index) of \(total)…"
+        if let cached = self.lastEnumerated { self.applyWorktreeResults(cached) }
+      },
+      completion: { [weak self] result in
+        guard let self = self else { return }
+        for c in candidates { self.pendingRemovals.remove(c.worktree.path) }
+        self.sweepRemovalPhase = false
+        self.setSweepStatus(nil, for: repoRoot)
+        if self.sweepDeferredRefresh {
+          self.sweepDeferredRefresh = false
+          self.refreshWorktrees()
+        }
+
+        let removed = result.removed.count
+        let noun = removed == 1 ? "workspace" : "workspaces"
+        if result.failures.isEmpty {
+          NotificationManager.shared.sendWatchdogNotification(
+            title: "Removed \(removed) \(noun)",
+            body: result.removed.map { "\($0.name) (PR #\($0.prNumber))" }
+              .joined(separator: ", "))
+        } else {
+          let failed = result.failures.map { "\($0.candidate.name): \($0.message)" }
+            .joined(separator: "\n")
+          NotificationManager.shared.sendWatchdogNotification(
+            title: "Removed \(removed) \(noun), \(result.failures.count) failed",
+            body: failed)
+          self.showInfoSheet(
+            title: "Some Workspaces Couldn't Be Removed",
+            body: failed)
+        }
+      })
+  }
+
+  /// Set (or clear, with nil) the sweep status shown in a project's row and
+  /// repaint. Refreshes are guarded during the removal phase, so callers in
+  /// that phase repaint from cache themselves.
+  private func setSweepStatus(_ status: String?, for repoRoot: String) {
+    if let status = status {
+      sweepsInFlight[repoRoot] = status
+    } else {
+      sweepsInFlight.removeValue(forKey: repoRoot)
+    }
+    refreshWorktrees()
+  }
+
+  private func showInfoSheet(title: String, body: String) {
+    let alert = NSAlert()
+    alert.messageText = title
+    alert.informativeText = body
+    alert.alertStyle = .informational
+    alert.addButton(withTitle: "OK")
+    if let win = window {
+      alert.beginSheetModal(for: win)
+    } else {
+      alert.runModal()
     }
   }
 

--- a/Sources/DraftFrameKit/PRMonitor.swift
+++ b/Sources/DraftFrameKit/PRMonitor.swift
@@ -150,8 +150,8 @@ final class PRMonitor {
   /// How often to hit `gh pr view` per session.
   private static let pollInterval: TimeInterval = 30
 
-  /// Cached PATH with Homebrew dirs prepended, computed once at init.
-  private let composedPATH: String = {
+  /// Cached PATH with Homebrew dirs prepended, computed once.
+  nonisolated private static let composedPATH: String = {
     let homebrewPaths = ["/opt/homebrew/bin", "/opt/homebrew/sbin", "/usr/local/bin"]
     let inherited = ProcessInfo.processInfo.environment["PATH"] ?? ""
     let parts = inherited.split(separator: ":").map(String.init)
@@ -265,7 +265,7 @@ final class PRMonitor {
       return
     }
 
-    let output = runGH(
+    let output = Self.runGH(
       args: ["pr", "view", "--json", "number,state,url,statusCheckRollup,autoMergeRequest"],
       cwd: worktreePath
     )
@@ -410,7 +410,7 @@ final class PRMonitor {
   private func fireAutoMerge(sessionID: UUID, worktreePath: String, status: PRStatus) {
     queue.async { [weak self] in
       guard let self = self else { return }
-      let output = self.runGH(
+      let output = Self.runGH(
         args: ["pr", "merge", "--squash", "--auto"],
         cwd: worktreePath
       )
@@ -472,7 +472,9 @@ final class PRMonitor {
 
   // MARK: - gh shell out
 
-  nonisolated private func runGH(args: [String], cwd: String) -> String {
+  /// Run `gh` with `args` in `cwd` and return its stdout. Blocks until gh
+  /// exits — never call from the main thread. Shared with `WorktreeSweeper`.
+  nonisolated static func runGH(args: [String], cwd: String) -> String {
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
     proc.arguments = ["gh"] + args

--- a/Sources/DraftFrameKit/WorktreeManager.swift
+++ b/Sources/DraftFrameKit/WorktreeManager.swift
@@ -8,7 +8,7 @@ final class WorktreeManager {
   // its long-standing cross-thread use.
   nonisolated(unsafe) static let shared = WorktreeManager()
 
-  struct Worktree {
+  struct Worktree: Equatable {
     let path: String
     let branch: String
     let head: String

--- a/Sources/DraftFrameKit/WorktreeSweeper.swift
+++ b/Sources/DraftFrameKit/WorktreeSweeper.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// A merged pull request as reported by `gh pr list --state merged`.
+struct MergedPR: Equatable {
+  let number: Int
+  let headRefName: String
+  let url: String
+}
+
+/// A managed worktree whose branch has a merged PR — a candidate for the
+/// sidebar's sweep.
+struct SweepCandidate: Equatable {
+  let worktree: WorktreeManager.Worktree
+  let prNumber: Int
+  let prURL: String
+
+  /// Directory name, as shown in the sidebar.
+  var name: String { (worktree.path as NSString).lastPathComponent }
+}
+
+/// Outcome of one sweep: which worktrees were removed and which failed.
+struct SweepResult {
+  var removed: [SweepCandidate] = []
+  var failures: [(candidate: SweepCandidate, message: String)] = []
+}
+
+/// Sweeps draftframe-managed worktrees whose PRs have merged.
+///
+/// Auto-archive in `PRMonitor` only catches a merge while the worktree has a
+/// live session; worktrees that predate the feature, lost their session, or
+/// merged while the app was closed accumulate under `.claude/worktrees/`.
+/// The sweep finds them with a single `gh pr list` per repo, then removes the
+/// user-confirmed set one at a time (removals contend on the repo's index
+/// lock, so a serial queue is the right shape). All subprocess work runs on
+/// `queue`; callers get results on the main actor.
+@MainActor
+final class WorktreeSweeper {
+  static let shared = WorktreeSweeper()
+
+  /// Page size for `gh pr list`. Repos with more merged PRs than this fall
+  /// back to a per-worktree `gh pr view` for the unmatched remainder.
+  nonisolated static let listLimit = 200
+
+  private let queue = DispatchQueue(label: "com.draftframe.worktree-sweep", qos: .utility)
+
+  private init() {}
+
+  // MARK: - Pure matching (unit-tested)
+
+  /// Parse `gh pr list --json number,headRefName,url` output. Entries missing
+  /// any field are skipped rather than failing the whole list.
+  nonisolated static func parseMergedPRList(_ data: Data) -> [MergedPR] {
+    guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+      return []
+    }
+    return arr.compactMap { entry in
+      guard let number = entry["number"] as? Int,
+        let head = entry["headRefName"] as? String,
+        let url = entry["url"] as? String
+      else { return nil }
+      return MergedPR(number: number, headRefName: head, url: url)
+    }
+  }
+
+  /// Managed, non-bare worktrees whose checked-out branch matches the head
+  /// branch of a merged PR. The primary checkout and any worktree living
+  /// outside `.claude/worktrees/` are never candidates, and a branch with no
+  /// merged PR (open, closed-unmerged, or no PR at all) is left alone. When
+  /// several merged PRs share a head branch (reopened and re-merged), the
+  /// highest-numbered one is reported.
+  nonisolated static func candidates(
+    worktrees: [WorktreeManager.Worktree], mergedPRs: [MergedPR]
+  ) -> [SweepCandidate] {
+    var byBranch: [String: MergedPR] = [:]
+    for pr in mergedPRs {
+      if let existing = byBranch[pr.headRefName], existing.number >= pr.number { continue }
+      byBranch[pr.headRefName] = pr
+    }
+    return worktrees.compactMap { wt in
+      guard !wt.isBare, !wt.branch.isEmpty,
+        WorktreeManager.isManagedWorktree(wt.path),
+        let pr = byBranch[wt.branch]
+      else { return nil }
+      return SweepCandidate(worktree: wt, prNumber: pr.number, prURL: pr.url)
+    }
+  }
+
+  // MARK: - Scan
+
+  /// Find sweep candidates for the repo rooted at `repoRoot`. Runs git and
+  /// gh off the main thread; `completion` is called on the main actor.
+  func scan(repoRoot: String, completion: @escaping @MainActor ([SweepCandidate]) -> Void) {
+    queue.async {
+      let found = Self.scanSync(repoRoot: repoRoot)
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated { completion(found) }
+      }
+    }
+  }
+
+  nonisolated private static func scanSync(repoRoot: String) -> [SweepCandidate] {
+    let worktrees = WorktreeManager.shared.listWorktrees(repoRoot: repoRoot)
+      .filter { !$0.isBare && WorktreeManager.isManagedWorktree($0.path) }
+    guard !worktrees.isEmpty else { return [] }
+
+    let output = PRMonitor.runGH(
+      args: [
+        "pr", "list", "--state", "merged", "--json", "number,headRefName,url",
+        "--limit", String(listLimit),
+      ],
+      cwd: repoRoot)
+    let merged = parseMergedPRList(output.data(using: .utf8) ?? Data())
+    var found = candidates(worktrees: worktrees, mergedPRs: merged)
+
+    // A full page means older merged PRs may have been cut off; look the
+    // unmatched worktrees up individually so a long-lived repo still sweeps
+    // cleanly. Below the limit the list is exhaustive and this is skipped.
+    if merged.count >= listLimit {
+      let matched = Set(found.map { $0.worktree.path })
+      for wt in worktrees where !matched.contains(wt.path) {
+        if let pr = lookupMergedPR(branch: wt.branch, cwd: repoRoot) {
+          found.append(SweepCandidate(worktree: wt, prNumber: pr.number, prURL: pr.url))
+        }
+      }
+    }
+    return found
+  }
+
+  /// Per-branch fallback: `gh pr view <branch>` resolves the branch's PR
+  /// (most recent if several). Returns it only when merged.
+  nonisolated private static func lookupMergedPR(branch: String, cwd: String) -> MergedPR? {
+    let output = PRMonitor.runGH(
+      args: ["pr", "view", branch, "--json", "number,state,url,headRefName"], cwd: cwd)
+    guard let data = output.data(using: .utf8),
+      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      obj["state"] as? String == PRState.merged.rawValue,
+      let number = obj["number"] as? Int,
+      let url = obj["url"] as? String
+    else { return nil }
+    return MergedPR(number: number, headRefName: branch, url: url)
+  }
+
+  // MARK: - Removal
+
+  /// Remove `candidates` one at a time. Each attached session is closed
+  /// through `SessionManager.closeSession` first (on the main actor, so
+  /// persistence stays consistent and the worktree isn't resumed on next
+  /// launch), then `git worktree remove` runs on the sweep queue. A failed
+  /// removal is recorded and the sweep moves on. `progress` fires on the
+  /// main actor before each removal with (index, total); `completion` fires
+  /// once at the end.
+  func sweep(
+    repoRoot: String,
+    candidates: [SweepCandidate],
+    progress: @escaping @MainActor (Int, Int) -> Void,
+    completion: @escaping @MainActor (SweepResult) -> Void
+  ) {
+    let total = candidates.count
+    var result = SweepResult()
+
+    func step(_ index: Int) {
+      guard index < total else {
+        completion(result)
+        return
+      }
+      let candidate = candidates[index]
+      progress(index + 1, total)
+      Self.closeSessions(attachedTo: candidate.worktree.path)
+
+      let path = candidate.worktree.path
+      queue.async {
+        let error: String?
+        do {
+          try WorktreeManager.shared.removeWorktree(repoRoot: repoRoot, path: path)
+          error = nil
+        } catch let err {
+          error = err.localizedDescription
+        }
+        DispatchQueue.main.async {
+          MainActor.assumeIsolated {
+            if let error = error {
+              NSLog("[WorktreeSweeper] remove failed for %@: %@", path, error)
+              result.failures.append((candidate, error))
+            } else {
+              result.removed.append(candidate)
+            }
+            step(index + 1)
+          }
+        }
+      }
+    }
+    step(0)
+  }
+
+  /// Close every session bound to `worktreePath`. Matches on symlink-resolved
+  /// paths: git reports realpaths while a session may hold the spelling the
+  /// user opened it with.
+  private static func closeSessions(attachedTo worktreePath: String) {
+    let resolved = URL(fileURLWithPath: worktreePath).resolvingSymlinksInPath().path
+    let ids = SessionManager.shared.sessions.compactMap { session -> UUID? in
+      guard let p = session.worktreePath else { return nil }
+      let same =
+        p == worktreePath
+        || URL(fileURLWithPath: p).resolvingSymlinksInPath().path == resolved
+      return same ? session.id : nil
+    }
+    for id in ids {
+      SessionManager.shared.closeSession(id: id)
+    }
+  }
+}

--- a/Tests/DraftFrameTests/WorktreeSweeperTests.swift
+++ b/Tests/DraftFrameTests/WorktreeSweeperTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+/// Covers the pure branch-to-merged-PR matching behind the sidebar's sweep.
+final class WorktreeSweeperTests: XCTestCase {
+
+  private let root = "/repo"
+  private var managed: String { root + WorktreeManager.worktreeSubpath }
+
+  private func worktree(
+    _ path: String, branch: String, isBare: Bool = false
+  ) -> WorktreeManager.Worktree {
+    WorktreeManager.Worktree(path: path, branch: branch, head: "abc", isBare: isBare)
+  }
+
+  private func pr(_ number: Int, _ branch: String) -> MergedPR {
+    MergedPR(number: number, headRefName: branch, url: "https://example.com/pull/\(number)")
+  }
+
+  // MARK: - Matching
+
+  func testMatchesManagedWorktreesWhoseBranchHasMergedPR() {
+    let merged = worktree("\(managed)/issue-1", branch: "issue-1")
+    let open = worktree("\(managed)/issue-2", branch: "issue-2")
+    let result = WorktreeSweeper.candidates(
+      worktrees: [merged, open], mergedPRs: [pr(10, "issue-1"), pr(11, "unrelated")])
+
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result.first?.worktree, merged)
+    XCTAssertEqual(result.first?.prNumber, 10)
+    XCTAssertEqual(result.first?.prURL, "https://example.com/pull/10")
+    XCTAssertEqual(result.first?.name, "issue-1")
+  }
+
+  func testSkipsPrimaryCheckoutAndUnmanagedWorktrees() {
+    let primary = worktree(root, branch: "main")
+    let elsewhere = worktree("/tmp/other-checkout", branch: "feature")
+    let result = WorktreeSweeper.candidates(
+      worktrees: [primary, elsewhere], mergedPRs: [pr(1, "main"), pr(2, "feature")])
+    XCTAssertTrue(result.isEmpty)
+  }
+
+  func testSkipsBareAndDetachedWorktrees() {
+    let bare = worktree("\(managed)/bare", branch: "feature", isBare: true)
+    let detached = worktree("\(managed)/detached", branch: "")
+    let result = WorktreeSweeper.candidates(
+      worktrees: [bare, detached], mergedPRs: [pr(1, "feature"), pr(2, "")])
+    XCTAssertTrue(result.isEmpty)
+  }
+
+  func testNoMergedPRsYieldsNoCandidates() {
+    let wt = worktree("\(managed)/issue-1", branch: "issue-1")
+    XCTAssertTrue(WorktreeSweeper.candidates(worktrees: [wt], mergedPRs: []).isEmpty)
+  }
+
+  func testMatchesOnBranchNotDirectoryName() {
+    // Slash branches live in dash-named directories.
+    let wt = worktree("\(managed)/feat-login", branch: "feat/login")
+    let result = WorktreeSweeper.candidates(
+      worktrees: [wt], mergedPRs: [pr(5, "feat/login"), pr(6, "feat-login")])
+    XCTAssertEqual(result.map(\.prNumber), [5])
+  }
+
+  func testPrefersHighestNumberedPRForBranch() {
+    let wt = worktree("\(managed)/issue-1", branch: "issue-1")
+    let result = WorktreeSweeper.candidates(
+      worktrees: [wt], mergedPRs: [pr(12, "issue-1"), pr(7, "issue-1")])
+    XCTAssertEqual(result.map(\.prNumber), [12])
+  }
+
+  func testPreservesWorktreeOrder() {
+    let a = worktree("\(managed)/a", branch: "a")
+    let b = worktree("\(managed)/b", branch: "b")
+    let c = worktree("\(managed)/c", branch: "c")
+    let result = WorktreeSweeper.candidates(
+      worktrees: [a, b, c], mergedPRs: [pr(3, "c"), pr(1, "a")])
+    XCTAssertEqual(result.map(\.name), ["a", "c"])
+  }
+
+  // MARK: - Parsing
+
+  func testParsesGHPRListOutput() {
+    let json = """
+      [
+        {"number": 23, "headRefName": "issue-22-persistent-state", "url": "https://x/pull/23"},
+        {"number": 24, "headRefName": "fix/thing", "url": "https://x/pull/24"}
+      ]
+      """
+    let parsed = WorktreeSweeper.parseMergedPRList(Data(json.utf8))
+    XCTAssertEqual(
+      parsed,
+      [
+        MergedPR(number: 23, headRefName: "issue-22-persistent-state", url: "https://x/pull/23"),
+        MergedPR(number: 24, headRefName: "fix/thing", url: "https://x/pull/24"),
+      ])
+  }
+
+  func testParseSkipsMalformedEntriesAndToleratesGarbage() {
+    let json = """
+      [{"number": 1, "headRefName": "ok", "url": "u"}, {"number": "2", "headRefName": "bad"}]
+      """
+    XCTAssertEqual(WorktreeSweeper.parseMergedPRList(Data(json.utf8)).map(\.number), [1])
+    XCTAssertTrue(WorktreeSweeper.parseMergedPRList(Data()).isEmpty)
+    XCTAssertTrue(WorktreeSweeper.parseMergedPRList(Data("not json".utf8)).isEmpty)
+  }
+}


### PR DESCRIPTION
Closes #26.

## Summary

Adds a "Remove Merged Workspaces…" item to each project row's context menu in the sidebar. It finds every draftframe-managed worktree (under `.claude/worktrees/`) whose branch has a merged PR, lists them in a confirmation sheet with checkboxes (all checked by default), then closes any attached sessions and removes the selected worktrees one at a time.

The design moved from the issue's header-level broom button to a per-project context menu item, so it is always clear which project is being swept.

## Implementation

- `WorktreeSweeper` (new): one `gh pr list --state merged --json number,headRefName,url --limit 200` per repo, matched against `git worktree list` by branch name. Falls back to per-worktree `gh pr view` only when the list page is full. Scan and removals run on a utility serial queue; UI updates hop back to the main actor. Sessions are closed via `SessionManager.closeSession` so persistence stays consistent. Per-worktree failures are collected and the sweep continues.
- `DFSidebar`: context menu item, in-row spinner with "Scanning…" / "Removing N of M…" status, checkbox confirmation sheet, "Nothing to Remove" sheet, single summary notification at the end. Worktree list refreshes are deferred during the removal phase and replayed after.
- `PRMonitor.runGH` is now a nonisolated static so the sweeper shares its PATH handling.
- `WorktreeManager.Worktree` gains `Equatable`.

Only merged PRs qualify. Open, closed-unmerged, and PR-less worktrees are untouched, as are the primary checkout and worktrees outside `.claude/worktrees/`.

## Testing

- `WorktreeSweeperTests`: 9 tests covering branch matching, managed-path filtering, bare/detached skipping, slash-branch directory names, duplicate PRs per branch, ordering, and JSON parsing.
- Full suite: 155 tests pass. `swift-format lint --strict` clean.
- Verified in the running app via the QA bridge that the context menu and in-row status render correctly.