### PR TITLE
Rejoin rows Claude Code hard-wrapped so copied commands paste as single lines

### DIFF
--- a/.claude/skills/copy-fixtures/SKILL.md
+++ b/.claude/skills/copy-fixtures/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: copy-fixtures
+description: Print a fixed set of terminal fixtures for manually testing DraftFrame's selection copy (issue #25, LogicalLineJoiner). Run this inside a Claude Code session in DraftFrame, then drag-select each block, Cmd+C, and paste into a shell or editor to confirm wrapped rows re-join as logical lines while lists, tables and diffs keep their line breaks.
+---
+
+# Copy fixtures
+
+You are running inside DraftFrame's terminal. The human wants specific shapes
+drawn on screen so they can select them and press Cmd+C. Your job is
+reproduction, not authoring. Do exactly two things and nothing else.
+
+**Step 1.** Call the Bash tool once, with this command verbatim as a single
+string (it only echoes; it needs no network and changes nothing):
+
+echo "refactor the wrapper" && printf '%s\n' "the quick brown fox jumps over the lazy dog while this tool header wraps onto a second and third visual row of the terminal at any sensible window width"
+
+**Step 2.** Reply with the text between the BEGIN and END lines below,
+character for character. Do not include the BEGIN and END lines. Do not add a
+greeting, a summary, a closing sentence, headings of your own, or any
+sentence that is not already in the text. Do not reflow, shorten, or
+"improve" the wording: the line lengths are the test. Do not wrap any of it
+in a code fence except the one block that is already fenced.
+
+BEGIN
+COPY FIXTURES. Select each block, Cmd+C, paste into a shell or editor, compare with the Expected line. Pasted text must start at its first character with no leading gutter spaces.
+
+1. The ⏺ Bash( header above. Expected: pastes as ONE line containing the whole echo command. Repeat it starting the drag on the "e" of "echo" instead of column 0. Expected: still ONE line.
+
+2. Terminals draw text into a fixed grid of cells, so any line longer than the grid is wrapped by the terminal itself, but some programs wrap the text on their own before it ever reaches the terminal and emit each visual row as a separate line. Expected: this paragraph pastes as ONE line.
+
+3. https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbb.tar.gz then more words. Expected: ONE line with NO space anywhere inside the URL, and a space before "then".
+
+4. Lists:
+- Read the buffer line by line and note which rows carry the wrapped flag so that the copy path can decide where the logical line boundaries actually are in the output
+- Short second item
+1. Numbered item
+2. Another one
+Expected: the first bullet is ONE line; every other item stays on its own line.
+
+5. Table:
+| id    | UUID   | Stable identifier for the session row, never reused |
+|-------|--------|------------------------------------------------------|
+| title | String | Display name shown in the sidebar and the tab strip  |
+Expected: three lines, none glued to the previous one.
+
+6. Code:
+```swift
+guard let session = sessions.first(where: { $0.id == id }) else { return nil }
+let value = computeSomething(from: input, options: options, strict: true)
+return value
+```
+Expected: three lines.
+
+7. Fixed the 🐛 in parser.swift and updated the 日本語 handling so the ✅ status renders at the right column even when the row wraps onto the next line of the terminal display. Expected: ONE line, glyphs intact.
+
+Done. Also try the Quick Terminal: seq 1 5 there must copy as five lines.
+END

--- a/Sources/DraftFrameKit/BlockquoteScanner.swift
+++ b/Sources/DraftFrameKit/BlockquoteScanner.swift
@@ -17,7 +17,7 @@ enum BlockquoteScanner {
   /// returns NUL (U+0000) for cells Claude Code hasn't written — a blockquote's
   /// indent often arrives as NUL cells before the bar glyph rather than spaces,
   /// so we must skip those too or the bar is never found.
-  private static func isSkippable(_ c: Character) -> Bool {
+  static func isSkippable(_ c: Character) -> Bool {
     c == " " || c == "\t" || c == "\u{0}"
   }
 

--- a/Sources/DraftFrameKit/ClaudeTerminalView.swift
+++ b/Sources/DraftFrameKit/ClaudeTerminalView.swift
@@ -1086,6 +1086,35 @@ class ClaudeTerminalView: LocalProcessTerminalView {
     NSPasteboard.general.setString(text, forType: .string)
   }
 
+  // MARK: - Selection copy
+
+  /// Copy the selection as logical lines rather than visual rows.
+  ///
+  /// SwiftTerm's own copy already joins rows the terminal soft-wrapped (via
+  /// the buffer's `isWrapped` flag), but Claude Code wraps its output itself
+  /// and emits every visual row as a hard line, so a long command that wraps
+  /// on screen would otherwise paste into a shell as several broken commands.
+  /// `LogicalLineJoiner` re-joins those rows using the wrap column inferred
+  /// from the selection and the visible screen. Reached by Cmd+C (Edit menu)
+  /// and the context menu's Copy item alike.
+  override func copy(_ sender: Any) {
+    guard let raw = getSelection() else { return }
+    var text = raw
+    if joinsWrappedRowsOnCopy {
+      let term = getTerminal()
+      let screen = (0..<term.rows).map { renderedRow($0) }
+      text = LogicalLineJoiner.join(raw, columns: term.cols, screenRows: screen)
+    }
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(text, forType: .string)
+  }
+
+  /// Whether `copy(_:)` re-joins rows Claude Code hard-wrapped. On for Claude
+  /// sessions; off for the Quick Terminal, whose shell relies on terminal
+  /// wrapping (which SwiftTerm already handles) and where the heuristic
+  /// would risk gluing independent lines of program output.
+  var joinsWrappedRowsOnCopy = true
+
   // MARK: - Drag and Drop
 
   override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {

--- a/Sources/DraftFrameKit/ClaudeTerminalView.swift
+++ b/Sources/DraftFrameKit/ClaudeTerminalView.swift
@@ -1095,16 +1095,20 @@ class ClaudeTerminalView: LocalProcessTerminalView {
   /// and emits every visual row as a hard line, so a long command that wraps
   /// on screen would otherwise paste into a shell as several broken commands.
   /// `LogicalLineJoiner` re-joins those rows using the wrap column inferred
-  /// from the selection and the visible screen. Reached by Cmd+C (Edit menu)
+  /// from the selection and the visible screen, then drops the gutter indent
+  /// Claude Code puts in front of its output. Reached by Cmd+C (Edit menu)
   /// and the context menu's Copy item alike.
   override func copy(_ sender: Any) {
     guard let raw = getSelection() else { return }
     var text = raw
-    // Single-row selections have nothing to join; skip the screen scan.
-    if joinsWrappedRowsOnCopy, raw.contains("\n") {
-      let term = getTerminal()
-      let screen = (0..<term.rows).map { copyRow($0) }
-      text = LogicalLineJoiner.join(raw, columns: term.cols, screenRows: screen)
+    if joinsWrappedRowsOnCopy {
+      // Single-row selections have nothing to join; skip the screen scan.
+      if raw.contains("\n") {
+        let term = getTerminal()
+        let screen = (0..<term.rows).map { copyRow($0) }
+        text = LogicalLineJoiner.join(raw, columns: term.cols, screenRows: screen)
+      }
+      text = LogicalLineJoiner.stripCommonIndent(text)
     }
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(text, forType: .string)

--- a/Sources/DraftFrameKit/ClaudeTerminalView.swift
+++ b/Sources/DraftFrameKit/ClaudeTerminalView.swift
@@ -1100,20 +1100,32 @@ class ClaudeTerminalView: LocalProcessTerminalView {
   override func copy(_ sender: Any) {
     guard let raw = getSelection() else { return }
     var text = raw
-    if joinsWrappedRowsOnCopy {
+    // Single-row selections have nothing to join; skip the screen scan.
+    if joinsWrappedRowsOnCopy, raw.contains("\n") {
       let term = getTerminal()
-      let screen = (0..<term.rows).map { renderedRow($0) }
+      let screen = (0..<term.rows).map { copyRow($0) }
       text = LogicalLineJoiner.join(raw, columns: term.cols, screenRows: screen)
     }
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(text, forType: .string)
   }
 
-  /// Whether `copy(_:)` re-joins rows Claude Code hard-wrapped. On for Claude
-  /// sessions; off for the Quick Terminal, whose shell relies on terminal
-  /// wrapping (which SwiftTerm already handles) and where the heuristic
-  /// would risk gluing independent lines of program output.
-  var joinsWrappedRowsOnCopy = true
+  /// A visible row as the selection text would render it: the zero-width
+  /// stub cell after each wide glyph is dropped (as SwiftTerm's copy does),
+  /// so widths and suffix matches line up with `getSelection()`. Unlike
+  /// `renderedRow`, which keeps one character per column for click mapping.
+  private func copyRow(_ row: Int) -> String? {
+    guard let line = getTerminal().getLine(row: row) else { return nil }
+    return line.translateToString(trimRight: true, skipNullCellsFollowingWide: true)
+      .replacingOccurrences(of: "\u{0}", with: " ")
+  }
+
+  /// Whether `copy(_:)` re-joins rows Claude Code hard-wrapped. Off by
+  /// default; `SessionManager` turns it on for Claude Code sessions only. A
+  /// plain shell (the Quick Terminal) or Codex relies on terminal wrapping,
+  /// which SwiftTerm already joins, and the heuristic would only risk gluing
+  /// independent lines of program output.
+  var joinsWrappedRowsOnCopy = false
 
   // MARK: - Drag and Drop
 

--- a/Sources/DraftFrameKit/DFQuickTerminal.swift
+++ b/Sources/DraftFrameKit/DFQuickTerminal.swift
@@ -628,10 +628,6 @@ final class DFQuickTerminal {
   /// Build a fresh terminal pane and start its shell.
   private func makePane(sessionID: UUID, workingDirectory: String?) -> QTPane {
     let tv = ClaudeTerminalView(frame: .zero)
-    // A plain shell: the terminal does the wrapping here, and SwiftTerm's own
-    // copy already joins those rows. The Claude Code re-wrap heuristic would
-    // only risk gluing independent lines of program output.
-    tv.joinsWrappedRowsOnCopy = false
     tv.translatesAutoresizingMaskIntoConstraints = false
     tv.nativeForegroundColor = Theme.text1
     tv.nativeBackgroundColor = Theme.bg

--- a/Sources/DraftFrameKit/DFQuickTerminal.swift
+++ b/Sources/DraftFrameKit/DFQuickTerminal.swift
@@ -628,6 +628,10 @@ final class DFQuickTerminal {
   /// Build a fresh terminal pane and start its shell.
   private func makePane(sessionID: UUID, workingDirectory: String?) -> QTPane {
     let tv = ClaudeTerminalView(frame: .zero)
+    // A plain shell: the terminal does the wrapping here, and SwiftTerm's own
+    // copy already joins those rows. The Claude Code re-wrap heuristic would
+    // only risk gluing independent lines of program output.
+    tv.joinsWrappedRowsOnCopy = false
     tv.translatesAutoresizingMaskIntoConstraints = false
     tv.nativeForegroundColor = Theme.text1
     tv.nativeBackgroundColor = Theme.bg

--- a/Sources/DraftFrameKit/LogicalLineJoiner.swift
+++ b/Sources/DraftFrameKit/LogicalLineJoiner.swift
@@ -24,8 +24,12 @@ import Foundation
 /// Anything else stays a hard newline. In particular a row that starts a new
 /// list item or structural glyph, a row whose indent is shallower than the
 /// row above, or a blank row always breaks. The heuristic is necessarily
-/// ambiguous for two independent lines that happen to satisfy the width test,
-/// so it is only applied to Claude sessions, never to a plain shell.
+/// ambiguous for two independent lines that happen to satisfy the width test
+/// (a code line that nearly fills the width followed by a line whose first
+/// token would not have fit; a row that is exactly full and ends in a long
+/// token followed by another long token, which is byte-identical to a hard
+/// split), so it is only applied to Claude Code sessions, never to a plain
+/// shell or another agent's TUI.
 enum LogicalLineJoiner {
 
   /// The wrap column must reach this fraction of the terminal width before
@@ -39,13 +43,13 @@ enum LogicalLineJoiner {
   /// Ink's wrap column and to recover the full width of the first selected
   /// row when the drag began mid-row.
   static func join(_ text: String, columns: Int, screenRows: [String?]) -> String {
-    let firstLine =
-      text.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
-      .first.map(String.init) ?? ""
+    let head = text.split(separator: "\n", maxSplits: 2, omittingEmptySubsequences: false)
+    guard head.count > 1 else { return text }
     return join(
       text, columns: columns,
       screenWrapColumn: wrapColumn(forScreenRows: screenRows),
-      firstRowWidth: fullRowWidth(endingWith: firstLine, in: screenRows))
+      firstRowWidth: fullRowWidth(
+        endingWith: String(head[0]), followedBy: String(head[1]), in: screenRows))
   }
 
   /// Core of `join`. `screenWrapColumn` is the wrap column inferred from the
@@ -66,7 +70,12 @@ enum LogicalLineJoiner {
     if let firstRowWidth, firstRowWidth > widths[0], firstRowWidth <= columns {
       widths[0] = firstRowWidth
     }
-    let selectionMax = widths.filter { $0 <= columns }.max() ?? 0
+    // Chrome rows (a rule between turns, a box border) span the full width
+    // and would otherwise stop any text row from counting as filled.
+    let selectionMax =
+      zip(lines, widths)
+      .filter { $0.1 <= columns && isTextRow($0.0) }
+      .map { $0.1 }.max() ?? 0
     let wrapColumn = max(selectionMax, min(screenWrapColumn ?? 0, columns))
     guard Double(wrapColumn) >= Double(columns) * minimumWrapFraction else { return text }
 
@@ -79,11 +88,12 @@ enum LogicalLineJoiner {
       switch decision {
       case .none:
         result.append(row)
-      case .word:
-        result[result.count - 1] =
-          trimTrailingBlank(result[result.count - 1]) + " " + content(of: row)
-      case .hardSplit:
-        result[result.count - 1] = trimTrailingBlank(result[result.count - 1]) + content(of: row)
+      case .word, .hardSplit:
+        var last = result.removeLast()
+        while let c = last.last, isBlank(c) { last.removeLast() }
+        if decision == .word { last.append(" ") }
+        last.append(content(of: row))
+        result.append(last)
       }
     }
     return result.joined(separator: "\n")
@@ -95,25 +105,41 @@ enum LogicalLineJoiner {
   /// ignored. Nil when nothing qualifies.
   static func wrapColumn(forScreenRows rows: [String?]) -> Int? {
     var best = 0
-    for case let row? in rows {
-      let trimmed = trimTrailingBlank(row)
-      guard trimmed.contains(where: isTextGlyph) else { continue }
-      if let first = trimmed.first(where: { !isBlank($0) }), isBoxDrawing(first) { continue }
-      if let last = trimmed.last, isBoxDrawing(last) { continue }
-      best = max(best, displayWidth(trimmed))
+    for case let row? in rows where isTextRow(row) {
+      best = max(best, displayWidth(trimTrailingBlank(row)))
     }
     return best > 0 ? best : nil
   }
 
-  /// Width of the on-screen row whose text ends with `line`, when `line` is
-  /// the tail of that row (the selection began mid-row). Nil when no row
-  /// matches or the match is not at a word boundary.
-  static func fullRowWidth(endingWith line: String, in rows: [String?]) -> Int? {
+  /// A row that carries text and is not chrome: rows bounded by box-drawing
+  /// (the input box, tool-call frames, the rule between turns) span the full
+  /// terminal width and say nothing about where Ink wrapped.
+  static func isTextRow(_ row: String) -> Bool {
+    let trimmed = trimTrailingBlank(row)
+    guard trimmed.contains(where: isTextGlyph) else { return false }
+    if let first = trimmed.first(where: { !isBlank($0) }), isBoxDrawing(first) { return false }
+    if let last = trimmed.last, isBoxDrawing(last) { return false }
+    return true
+  }
+
+  /// Width of the on-screen row the selection started on, when `line` (the
+  /// first selected line) is only the tail of that row because the drag began
+  /// mid-row. The match is anchored: the row must end with `line` at a word
+  /// boundary *and* be followed on screen by the second selected line, so an
+  /// unrelated row elsewhere that happens to end the same way is not taken.
+  /// Nil when the selection is not on screen or already starts at the row's
+  /// first column.
+  static func fullRowWidth(endingWith line: String, followedBy next: String, in rows: [String?])
+    -> Int?
+  {
     let tail = trimTrailingBlank(line)
+    let nextTrimmed = trimTrailingBlank(next)
     guard !tail.isEmpty, tail.contains(where: isTextGlyph) else { return nil }
-    for case let row? in rows {
+    for i in rows.indices.dropLast() {
+      guard let row = rows[i], let below = rows[i + 1] else { continue }
       let trimmed = trimTrailingBlank(row)
       guard trimmed.count > tail.count, trimmed.hasSuffix(tail) else { continue }
+      guard trimTrailingBlank(below) == nextTrimmed else { continue }
       let boundary = trimmed.index(trimmed.endIndex, offsetBy: -tail.count)
       let before = trimmed[trimmed.index(before: boundary)]
       guard isBlank(before) || !isTextGlyph(before) || !isTextGlyph(tail.first!) else { continue }
@@ -165,19 +191,22 @@ enum LogicalLineJoiner {
   // MARK: - Row anatomy
 
   /// Glyphs that open a new list item or structural row in Claude Code's
-  /// output. A row beginning with one of these is never a continuation.
-  /// Shell-significant characters (`>`, `#`, `|`, `&`) are deliberately
+  /// output: bullets, tool-call markers, checkboxes, the quote bar, and the
+  /// `|` of a Markdown table cell. A row beginning with one of these is never
+  /// a continuation. Shell-significant `>`, `#` and `&` are deliberately
   /// absent so a wrapped command whose continuation starts with a redirect
   /// or comment still joins.
-  private static let itemGlyphs: Set<Character> = [
-    "•", "◦", "▪", "⏺", "⎿", "☐", "☒", "✓", "✔", "✗", "✘", "›", "❯",
-    "▏", "▎", "▍", "▌", "▋", "▊", "▉",
-  ]
+  private static let itemGlyphs: Set<Character> = Set<Character>([
+    "•", "◦", "▪", "⏺", "⎿", "☐", "☒", "✓", "✔", "✗", "✘", "›", "❯", "|",
+  ]).union(BlockquoteScanner.barGlyphs)
 
-  private static let numberedItem = try! NSRegularExpression(pattern: "^[0-9]{1,3}[.)]\\s")
+  /// "1. item", "2) item", and the line-number gutter of an Edit-tool diff
+  /// ("12 +    let value = ..."), which is digits followed by whitespace.
+  private static let numberedItem = try! NSRegularExpression(pattern: "^[0-9]{1,4}(?:[.)])?\\s")
 
   /// True when `content` (indent already stripped) opens a list item, a
-  /// quote bar, a tool-call marker, or a box-drawing frame.
+  /// table cell, a diff gutter, a quote bar, a tool-call marker, or a
+  /// box-drawing frame.
   static func startsNewItem(_ content: String) -> Bool {
     guard let first = content.first else { return false }
     if itemGlyphs.contains(first) || isBoxDrawing(first) { return true }
@@ -194,7 +223,7 @@ enum LogicalLineJoiner {
   }
 
   private static func isBlank(_ c: Character) -> Bool {
-    c == " " || c == "\t" || c == "\u{0}"
+    BlockquoteScanner.isSkippable(c)
   }
 
   private static func isBoxDrawing(_ c: Character) -> Bool {

--- a/Sources/DraftFrameKit/LogicalLineJoiner.swift
+++ b/Sources/DraftFrameKit/LogicalLineJoiner.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+/// Rebuilds logical lines from the rows Claude Code's TUI drew.
+///
+/// SwiftTerm already joins rows the *terminal* soft-wrapped (it tracks an
+/// `isWrapped` flag per buffer line), but Claude Code's Ink renderer never
+/// relies on terminal wrapping: it word-wraps text itself at a content width
+/// short of the terminal edge and emits every visual row as its own line,
+/// re-emitting the block's left indent on each continuation row. So a long
+/// command that visibly wraps copies with a hard newline at every row
+/// boundary, and pasting it into a shell runs it as several broken commands.
+///
+/// This replays Ink's wrapping decision (`wrap-ansi` with `hard: true`) in
+/// reverse. For two adjacent rows `a` and `b`, `b` is a continuation of `a`
+/// when Ink could not have fit `b`'s first word on `a`:
+///
+/// - **Hard split**: `a` is exactly as wide as the widest row selected (so it
+///   fills the wrap column) and the token straddling the seam (`a`'s trailing
+///   word plus `b`'s leading word) is wider than the block's text width, the
+///   only case in which Ink splits inside a word. Joined with nothing.
+/// - **Word wrap**: `a`'s width plus a space plus `b`'s first word overflows
+///   the wrap column. Joined with a space.
+///
+/// Anything else stays a hard newline. In particular a row that starts a new
+/// list item or structural glyph, a row whose indent is shallower than the
+/// row above, or a blank row always breaks. The heuristic is necessarily
+/// ambiguous for two independent lines that happen to satisfy the width test,
+/// so it is only applied to Claude sessions, never to a plain shell.
+enum LogicalLineJoiner {
+
+  /// The wrap column must reach this fraction of the terminal width before
+  /// any joining happens. A selection whose rows all end well short of the
+  /// edge (a few short lines, a narrow list) carries no wrap information, and
+  /// joining on it would glue independent lines.
+  static let minimumWrapFraction = 0.6
+
+  /// Join the selection `text` (the newline-separated pieces SwiftTerm
+  /// produced) into logical lines, using the visible `screenRows` to estimate
+  /// Ink's wrap column and to recover the full width of the first selected
+  /// row when the drag began mid-row.
+  static func join(_ text: String, columns: Int, screenRows: [String?]) -> String {
+    let firstLine =
+      text.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+      .first.map(String.init) ?? ""
+    return join(
+      text, columns: columns,
+      screenWrapColumn: wrapColumn(forScreenRows: screenRows),
+      firstRowWidth: fullRowWidth(endingWith: firstLine, in: screenRows))
+  }
+
+  /// Core of `join`. `screenWrapColumn` is the wrap column inferred from the
+  /// screen (nil if unknown); the widest selected row is also consulted, so a
+  /// wrapped command selected while scrolled into scrollback still joins.
+  /// `firstRowWidth` is the on-screen width of the row the selection starts
+  /// on, when the first line is only the tail of that row.
+  static func join(
+    _ text: String, columns: Int, screenWrapColumn: Int?, firstRowWidth: Int? = nil
+  ) -> String {
+    let lines = text.components(separatedBy: "\n")
+    guard lines.count > 1, columns > 0 else { return text }
+
+    // Widths of the rows as drawn. SwiftTerm has already joined
+    // terminal-wrapped rows, and those can exceed the column count; they are
+    // never the head of an Ink wrap so they are excluded from the estimate.
+    var widths = lines.map { displayWidth(trimTrailingBlank($0)) }
+    if let firstRowWidth, firstRowWidth > widths[0], firstRowWidth <= columns {
+      widths[0] = firstRowWidth
+    }
+    let selectionMax = widths.filter { $0 <= columns }.max() ?? 0
+    let wrapColumn = max(selectionMax, min(screenWrapColumn ?? 0, columns))
+    guard Double(wrapColumn) >= Double(columns) * minimumWrapFraction else { return text }
+
+    var result: [String] = [lines[0]]
+    for i in 1..<lines.count {
+      let row = lines[i]
+      let decision = continuation(
+        from: lines[i - 1], width: widths[i - 1], to: row,
+        wrapColumn: wrapColumn, fullRowColumn: selectionMax)
+      switch decision {
+      case .none:
+        result.append(row)
+      case .word:
+        result[result.count - 1] =
+          trimTrailingBlank(result[result.count - 1]) + " " + content(of: row)
+      case .hardSplit:
+        result[result.count - 1] = trimTrailingBlank(result[result.count - 1]) + content(of: row)
+      }
+    }
+    return result.joined(separator: "\n")
+  }
+
+  /// Estimate Ink's wrap column from the rows on screen: the widest row that
+  /// carries text and is not part of the chrome. Rows bounded by box-drawing
+  /// (the input box, tool-call frames) span the full terminal width and are
+  /// ignored. Nil when nothing qualifies.
+  static func wrapColumn(forScreenRows rows: [String?]) -> Int? {
+    var best = 0
+    for case let row? in rows {
+      let trimmed = trimTrailingBlank(row)
+      guard trimmed.contains(where: isTextGlyph) else { continue }
+      if let first = trimmed.first(where: { !isBlank($0) }), isBoxDrawing(first) { continue }
+      if let last = trimmed.last, isBoxDrawing(last) { continue }
+      best = max(best, displayWidth(trimmed))
+    }
+    return best > 0 ? best : nil
+  }
+
+  /// Width of the on-screen row whose text ends with `line`, when `line` is
+  /// the tail of that row (the selection began mid-row). Nil when no row
+  /// matches or the match is not at a word boundary.
+  static func fullRowWidth(endingWith line: String, in rows: [String?]) -> Int? {
+    let tail = trimTrailingBlank(line)
+    guard !tail.isEmpty, tail.contains(where: isTextGlyph) else { return nil }
+    for case let row? in rows {
+      let trimmed = trimTrailingBlank(row)
+      guard trimmed.count > tail.count, trimmed.hasSuffix(tail) else { continue }
+      let boundary = trimmed.index(trimmed.endIndex, offsetBy: -tail.count)
+      let before = trimmed[trimmed.index(before: boundary)]
+      guard isBlank(before) || !isTextGlyph(before) || !isTextGlyph(tail.first!) else { continue }
+      return displayWidth(trimmed)
+    }
+    return nil
+  }
+
+  // MARK: - Decision
+
+  enum Continuation { case none, word, hardSplit }
+
+  /// Decide whether row `b` continues row `a`. `width` is `a`'s drawn width
+  /// (which may exceed the visible fragment when the selection began
+  /// mid-row), `wrapColumn` the column Ink wrapped at, and `fullRowColumn`
+  /// the widest row in the selection, used to recognise rows Ink filled
+  /// completely.
+  static func continuation(
+    from a: String, width aWidth: Int, to b: String, wrapColumn: Int, fullRowColumn: Int
+  ) -> Continuation {
+    let a = trimTrailingBlank(a)
+    let bIndent = leadingBlankCount(b)
+    let bContent = content(of: b)
+    guard !a.isEmpty, !bContent.isEmpty else { return .none }
+    guard bIndent >= leadingBlankCount(a) else { return .none }
+    guard !startsNewItem(bContent) else { return .none }
+    // Only join onto something that reads as text: a border or rule row is
+    // never the head of a wrapped line.
+    guard a.contains(where: isTextGlyph), bContent.contains(where: isTextGlyph) else {
+      return .none
+    }
+    guard aWidth <= wrapColumn else { return .none }
+
+    let firstWord = displayWidth(String(bContent.prefix(while: { !$0.isWhitespace })))
+
+    // Ink splits inside a word only when the word is wider than the block's
+    // text region, which runs from the continuation indent to the row edge,
+    // and when it does the row is filled exactly. The test must be exact: the
+    // remainder of a split token typically ends a column or two short of the
+    // edge, and a lenient match would glue the following word onto it.
+    if aWidth == fullRowColumn {
+      let tail = displayWidth(String(a.reversed().prefix(while: { !$0.isWhitespace })))
+      if tail + firstWord > aWidth - bIndent { return .hardSplit }
+    }
+    if aWidth + 1 + firstWord > wrapColumn { return .word }
+    return .none
+  }
+
+  // MARK: - Row anatomy
+
+  /// Glyphs that open a new list item or structural row in Claude Code's
+  /// output. A row beginning with one of these is never a continuation.
+  /// Shell-significant characters (`>`, `#`, `|`, `&`) are deliberately
+  /// absent so a wrapped command whose continuation starts with a redirect
+  /// or comment still joins.
+  private static let itemGlyphs: Set<Character> = [
+    "•", "◦", "▪", "⏺", "⎿", "☐", "☒", "✓", "✔", "✗", "✘", "›", "❯",
+    "▏", "▎", "▍", "▌", "▋", "▊", "▉",
+  ]
+
+  private static let numberedItem = try! NSRegularExpression(pattern: "^[0-9]{1,3}[.)]\\s")
+
+  /// True when `content` (indent already stripped) opens a list item, a
+  /// quote bar, a tool-call marker, or a box-drawing frame.
+  static func startsNewItem(_ content: String) -> Bool {
+    guard let first = content.first else { return false }
+    if itemGlyphs.contains(first) || isBoxDrawing(first) { return true }
+    // "- item" / "* item" bullets, but not "--flag" or "*.swift".
+    if first == "-" || first == "*" {
+      let second = content.dropFirst().first
+      return second == " " || second == nil
+    }
+    if first.isNumber {
+      let range = NSRange(location: 0, length: (content as NSString).length)
+      return numberedItem.firstMatch(in: content, range: range) != nil
+    }
+    return false
+  }
+
+  private static func isBlank(_ c: Character) -> Bool {
+    c == " " || c == "\t" || c == "\u{0}"
+  }
+
+  private static func isBoxDrawing(_ c: Character) -> Bool {
+    guard let v = c.unicodeScalars.first?.value else { return false }
+    return (0x2500...0x257F).contains(v)
+  }
+
+  private static func leadingBlankCount(_ s: String) -> Int {
+    s.prefix(while: isBlank).count
+  }
+
+  private static func content(of row: String) -> String {
+    trimTrailingBlank(String(row.drop(while: isBlank)))
+  }
+
+  private static func trimTrailingBlank(_ s: String) -> String {
+    var s = s
+    while let last = s.last, isBlank(last) { s.removeLast() }
+    return s
+  }
+
+  private static func isTextGlyph(_ c: Character) -> Bool {
+    c.isLetter || c.isNumber
+  }
+
+  /// Terminal column width of `s`, matching what Ink's `string-width` sees:
+  /// combining marks and joiners are zero, East Asian wide/fullwidth and
+  /// emoji-presentation scalars are two, everything else is one.
+  static func displayWidth(_ s: String) -> Int {
+    var width = 0
+    for scalar in s.unicodeScalars {
+      let v = scalar.value
+      let category = scalar.properties.generalCategory
+      if v == 0 || v == 0x200B || v == 0x200D || (0xFE00...0xFE0F).contains(v)
+        || category == .nonspacingMark || category == .enclosingMark
+      {
+        continue
+      }
+      width += isWide(scalar) ? 2 : 1
+    }
+    return width
+  }
+
+  private static func isWide(_ scalar: Unicode.Scalar) -> Bool {
+    if scalar.properties.isEmojiPresentation { return true }
+    let v = scalar.value
+    return (0x1100...0x115F).contains(v)  // Hangul Jamo
+      || (0x2E80...0x303E).contains(v)  // CJK radicals, punctuation
+      || (0x3041...0x33FF).contains(v)  // Hiragana, Katakana, CJK compat
+      || (0x3400...0x4DBF).contains(v)  // CJK ext A
+      || (0x4E00...0x9FFF).contains(v)  // CJK unified
+      || (0xA000...0xA4CF).contains(v)  // Yi
+      || (0xAC00...0xD7A3).contains(v)  // Hangul syllables
+      || (0xF900...0xFAFF).contains(v)  // CJK compat ideographs
+      || (0xFE30...0xFE4F).contains(v)  // CJK compat forms
+      || (0xFF00...0xFF60).contains(v)  // Fullwidth forms
+      || (0xFFE0...0xFFE6).contains(v)
+      || (0x1F300...0x1F64F).contains(v)  // Pictographs, emoticons
+      || (0x1F680...0x1F6FF).contains(v)  // Transport
+      || (0x1F900...0x1F9FF).contains(v)  // Supplemental symbols
+      || (0x1FA70...0x1FAFF).contains(v)  // Symbols ext A
+      || (0x20000...0x3FFFD).contains(v)  // CJK ext B+
+  }
+}

--- a/Sources/DraftFrameKit/LogicalLineJoiner.swift
+++ b/Sources/DraftFrameKit/LogicalLineJoiner.swift
@@ -99,6 +99,17 @@ enum LogicalLineJoiner {
     return result.joined(separator: "\n")
   }
 
+  /// Drop the indent Claude Code's gutter adds to every row of its output,
+  /// so a pasted paragraph starts at its first word. Only the indent shared
+  /// by every non-blank line is removed, which keeps the relative indentation
+  /// of a code block intact.
+  static func stripCommonIndent(_ text: String) -> String {
+    let lines = text.components(separatedBy: "\n")
+    let indents = lines.filter { !$0.allSatisfy(isBlank) }.map(leadingBlankCount)
+    guard let common = indents.min(), common > 0 else { return text }
+    return lines.map { String($0.dropFirst(min(common, $0.count))) }.joined(separator: "\n")
+  }
+
   /// Estimate Ink's wrap column from the rows on screen: the widest row that
   /// carries text and is not part of the chrome. Rows bounded by box-drawing
   /// (the input box, tool-call frames) span the full terminal width and are

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -414,6 +414,9 @@ final class SessionManager {
     tv.selectedTextBackgroundColor = Theme.selected
     tv.caretColor = Theme.accent
     tv.font = Theme.terminalMono(13)
+    // The copy re-wrap heuristic models Claude Code's Ink renderer; Codex
+    // draws its own full-screen TUI and gets SwiftTerm's plain copy.
+    tv.joinsWrappedRowsOnCopy = agent == .claude
     session.terminalView = tv
 
     // Wire PTY data stream to the analyzer for real-time state detection

--- a/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
+++ b/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
@@ -1,0 +1,272 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+final class LogicalLineJoinerTests: XCTestCase {
+
+  /// Wrap column of a 60-column terminal once Claude Code's right margin is
+  /// taken off. Every fixture below is laid out against this width.
+  private let W = 58
+
+  /// Replay Ink's layout (`wrap-ansi`, `hard: true`) for one logical line:
+  /// word-wrap into rows no wider than `width`, splitting a word inside only
+  /// when the word alone is wider than the width. Each row is prefixed with
+  /// `indent` spaces (the first with `firstIndent`), so the rows end at the
+  /// same absolute column Ink would have used.
+  private func inkRows(_ text: String, width: Int, firstIndent: String, indent: String) -> [String]
+  {
+    var rows: [String] = [""]
+    func available(_ rowIndex: Int) -> Int {
+      width - (rowIndex == 0 ? firstIndent.count : indent.count)
+    }
+    for word in text.split(separator: " ", omittingEmptySubsequences: false).map(String.init) {
+      var word = word
+      var current = rows[rows.count - 1]
+      let cols = available(rows.count - 1)
+      if !current.isEmpty {
+        if current.count + 1 + word.count <= cols {
+          rows[rows.count - 1] = current + " " + word
+          continue
+        }
+        if word.count <= cols {
+          rows.append(word)
+          continue
+        }
+        // Hard split: fill the rest of this row, then whole rows.
+        let room = cols - current.count - 1
+        if room > 0 {
+          rows[rows.count - 1] = current + " " + word.prefix(room)
+          word = String(word.dropFirst(room))
+        }
+        rows.append("")
+        current = ""
+      }
+      while word.count > available(rows.count - 1) {
+        let cols = available(rows.count - 1)
+        rows[rows.count - 1] = String(word.prefix(cols))
+        word = String(word.dropFirst(cols))
+        rows.append("")
+      }
+      rows[rows.count - 1] = word
+    }
+    return rows.enumerated().map { ($0 == 0 ? firstIndent : indent) + $1 }
+  }
+
+  /// Join as `copy(_:)` would on a 60-column terminal whose screen estimate
+  /// resolved to `W`.
+  private func join(_ rows: [String], screenWrapColumn: Int? = 58, firstRowWidth: Int? = nil)
+    -> String
+  {
+    LogicalLineJoiner.join(
+      rows.joined(separator: "\n"), columns: 60, screenWrapColumn: screenWrapColumn,
+      firstRowWidth: firstRowWidth)
+  }
+
+  // MARK: - Wrapped commands
+
+  func testWordWrappedCommandJoinsWithSpace() {
+    let command =
+      "git commit --no-verify -m 'refactor the wrapper' && git push origin HEAD --force-with-lease"
+    let rows = inkRows(command, width: W, firstIndent: "⏺ Bash(", indent: "      ")
+    XCTAssertGreaterThan(rows.count, 1, "fixture must wrap")
+    XCTAssertEqual(join(rows), "⏺ Bash(" + command)
+  }
+
+  func testFlagOnContinuationRowIsNotABullet() {
+    // Continuation rows beginning with "--flag" must not read as "- item".
+    let rows = [
+      "  npm run build -- --configuration production --output-dir",
+      "  --no-cache dist",
+    ]
+    XCTAssertEqual(rows[0].count, W)
+    XCTAssertEqual(
+      join(rows),
+      "  npm run build -- --configuration production --output-dir --no-cache dist")
+  }
+
+  func testHardSplitTokenJoinsWithoutSeparator() {
+    // The URL is split at the row edge (joined with nothing); its remainder
+    // then ends short of the edge, so the following "-o" word-wraps (joined
+    // with a space). Note the remainder must not fill its row exactly: if it
+    // did, "remainder | -o" would be indistinguishable by width from a single
+    // split token, and no heuristic can tell those apart.
+    let url = "https://example.com/" + String(repeating: "a", count: 60) + "/bbb.tar.gz"
+    let command = "curl -fsSL \(url) -o out.tgz"
+    let rows = inkRows(command, width: W, firstIndent: "  ", indent: "  ")
+    XCTAssertEqual(rows.count, 3, "fixture must hard-split the URL once, then word-wrap")
+    XCTAssertEqual(rows[0].count, W)
+    XCTAssertLessThan(rows[1].count, W)
+    XCTAssertEqual(join(rows), "  " + command)
+  }
+
+  func testSoftWrappedRowAlreadyJoinedBySwiftTermIsLeftAlone() {
+    // A row wider than the wrap column can only come from SwiftTerm joining
+    // terminal-wrapped rows; it is never the head of an Ink wrap.
+    let long = String(repeating: "x", count: W + 10)
+    XCTAssertEqual(join([long, "next"]), long + "\nnext")
+  }
+
+  // MARK: - Prose and structure
+
+  func testParagraphJoinsAndBlankLineSeparatesParagraphs() {
+    let p1 =
+      "Terminals draw text into a fixed grid of cells, so any line longer than the grid is wrapped."
+    let p2 = "Some programs wrap the text themselves before it ever reaches the terminal."
+    let rows =
+      inkRows(p1, width: W, firstIndent: "  ", indent: "  ") + [""]
+      + inkRows(p2, width: W, firstIndent: "  ", indent: "  ")
+    XCTAssertEqual(join(rows), "  " + p1 + "\n\n  " + p2)
+  }
+
+  func testShortLinesWithSameIndentStaySeparate() {
+    let rows = ["  Here is the plan:", "  First, look at the tests."]
+    XCTAssertEqual(join(rows), rows.joined(separator: "\n"))
+  }
+
+  func testListItemsStaySeparateButWrappedItemJoins() {
+    let item1 = "Read the buffer line by line and note which rows carry the wrapped flag"
+    let rows =
+      inkRows(item1, width: W, firstIndent: "  - ", indent: "    ")
+      + ["  - Short second item", "  1. Numbered item", "  2. Another one", "  • Bulleted"]
+    XCTAssertGreaterThan(rows.count, 5)
+    XCTAssertEqual(
+      join(rows),
+      "  - " + item1 + "\n  - Short second item\n  1. Numbered item\n  2. Another one\n  • Bulleted"
+    )
+  }
+
+  func testIndentDecreaseBreaksLine() {
+    let rows = [
+      "      " + String(repeating: "word ", count: 9).trimmingCharacters(in: .whitespaces),
+      "  " + String(repeating: "w", count: 40),
+    ]
+    XCTAssertEqual(join(rows), rows.joined(separator: "\n"))
+  }
+
+  func testToolCallRowsStaySeparate() {
+    let rows = [
+      "⏺ Bash(git status --short && git log --oneline -3 && git diff",
+      "  ⎿  M Sources/App.swift",
+      "     M Tests/AppTests.swift",
+    ]
+    // "⎿" opens a result row; the last row is shallower-indented than the
+    // one above only relative to the glyph, so it stays a distinct row too.
+    XCTAssertEqual(join(rows), rows.joined(separator: "\n"))
+  }
+
+  func testBoxDrawingRowsNeverJoin() {
+    let rows = [
+      "╭" + String(repeating: "─", count: W - 2) + "╮",
+      "│ > some prompt text                                      │",
+      "╰" + String(repeating: "─", count: W - 2) + "╯",
+    ]
+    XCTAssertEqual(join(rows), rows.joined(separator: "\n"))
+  }
+
+  func testNarrowSelectionWithNoScreenEstimateLeavesTextUntouched() {
+    // Two independent lines that would satisfy the width test against their
+    // own widest row must not join: without a plausible wrap column (>= 60%
+    // of the terminal width) there is no wrap information to act on.
+    let rows = ["  Here is the plan for today:", "  First, look at the tests"]
+    XCTAssertEqual(join(rows, screenWrapColumn: nil), rows.joined(separator: "\n"))
+  }
+
+  func testWrappedCommandJoinsFromSelectionWidthAloneWhenScreenIsChrome() {
+    // Scrolled back to the bottom before Cmd+C: the screen offers no
+    // estimate, but the selection's own full row does.
+    let command =
+      "git commit --no-verify -m 'refactor the wrapper' && git push origin HEAD --force-with-lease"
+    let rows = inkRows(command, width: W, firstIndent: "⏺ Bash(", indent: "      ")
+    XCTAssertEqual(join(rows, screenWrapColumn: nil), "⏺ Bash(" + command)
+  }
+
+  // MARK: - Review scenarios
+
+  func testHardSplitInsideIndentedBlockUsesBlockTextWidth() {
+    // Ink splits a word when it exceeds the block's text width (W minus the
+    // continuation indent), not the full wrap column. A 55-char URL in a
+    // "⏺ Bash(" block (51 columns of text) is split; the seam must close.
+    let url = "https://x.io/" + String(repeating: "a", count: 42)
+    XCTAssertEqual(url.count, 55)
+    let head = "⏺ Bash(curl -fsSL "
+    let a = head + String(url.prefix(W - head.count))
+    let b = "      " + String(url.dropFirst(W - head.count)) + " -o out"
+    XCTAssertEqual(a.count, W)
+    XCTAssertEqual(join([a, b]), head + url + " -o out")
+  }
+
+  func testRedirectOnContinuationRowStillJoins() {
+    let rows = [
+      "⏺ Bash(make build 2>&1 | tee build.log && cat build.log &&",
+      "      > /dev/null || exit 1",
+    ]
+    XCTAssertEqual(
+      join(rows),
+      "⏺ Bash(make build 2>&1 | tee build.log && cat build.log && > /dev/null || exit 1")
+  }
+
+  func testTrailingSpacesOnHeadRowCollapseToOneSeparator() {
+    let a = "  git commit -m 'x' && git push origin main --force-with  "
+    let rows = [a, "  lease"]
+    XCTAssertEqual(join(rows), "  git commit -m 'x' && git push origin main --force-with lease")
+  }
+
+  func testSelectionStartingMidRowUsesFullRowWidth() {
+    let command =
+      "git commit --no-verify -m 'refactor the wrapper' && git push origin HEAD --force-with-lease"
+    let rows = inkRows(command, width: W, firstIndent: "⏺ Bash(", indent: "      ")
+    // The drag began at the "g" of "git": SwiftTerm hands us only the tail
+    // of the first row.
+    var partial = rows
+    partial[0] = String(rows[0].dropFirst("⏺ Bash(".count))
+    XCTAssertEqual(join(partial, firstRowWidth: rows[0].count), command)
+    // The screen-driven entry point recovers that width itself.
+    let screen: [String?] = ["  header"] + rows.map { Optional($0) } + [nil]
+    XCTAssertEqual(
+      LogicalLineJoiner.join(partial.joined(separator: "\n"), columns: 60, screenRows: screen),
+      command)
+  }
+
+  func testFullRowWidthRequiresWordBoundary() {
+    let rows: [String?] = ["  foo ls -la", "  something else"]
+    XCTAssertEqual(LogicalLineJoiner.fullRowWidth(endingWith: "ls -la", in: rows), 12)
+    XCTAssertNil(LogicalLineJoiner.fullRowWidth(endingWith: "s -la", in: rows))
+    XCTAssertNil(LogicalLineJoiner.fullRowWidth(endingWith: "  foo ls -la", in: rows))
+  }
+
+  func testWrapColumnIgnoresInputBoxRowWithText() {
+    let screen: [String?] = [
+      "  " + String(repeating: "t", count: W - 2),
+      "│ > Try \"fix the bug\"" + String(repeating: " ", count: 60 - 22) + "│",
+      "╭" + String(repeating: "─", count: 58) + "╮",
+    ]
+    XCTAssertEqual(LogicalLineJoiner.wrapColumn(forScreenRows: screen), W)
+  }
+
+  // MARK: - Wrap column estimate
+
+  func testWrapColumnIgnoresBorderRowsAndTakesWidestTextRow() {
+    let border = String(repeating: "─", count: 60)
+    let screen: [String?] = [
+      "  Some short text",
+      "  " + String(repeating: "t", count: W - 2),
+      border,
+      "> ",
+      nil,
+    ]
+    XCTAssertEqual(LogicalLineJoiner.wrapColumn(forScreenRows: screen), W)
+  }
+
+  func testWrapColumnIsNilForEmptyScreen() {
+    XCTAssertNil(LogicalLineJoiner.wrapColumn(forScreenRows: [nil, "", "> "]))
+  }
+
+  func testDisplayWidthCountsWideGlyphsAsTwo() {
+    XCTAssertEqual(LogicalLineJoiner.displayWidth("abc"), 3)
+    XCTAssertEqual(LogicalLineJoiner.displayWidth("日本"), 4)
+    XCTAssertEqual(LogicalLineJoiner.displayWidth("e\u{301}"), 1)
+    // Emoji-presentation scalars outside the pictograph block, and transport
+    // symbols, are two columns to Ink's string-width as well.
+    XCTAssertEqual(LogicalLineJoiner.displayWidth("🚀✅⚡🙂日"), 10)
+  }
+}

--- a/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
+++ b/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
@@ -6,7 +6,7 @@ final class LogicalLineJoinerTests: XCTestCase {
 
   /// Wrap column of a 60-column terminal once Claude Code's right margin is
   /// taken off. Every fixture below is laid out against this width.
-  private let W = 58
+  private let wrap = 58
 
   /// Replay Ink's layout (`wrap-ansi`, `hard: true`) for one logical line:
   /// word-wrap into rows no wider than `width`, splitting a word inside only
@@ -53,7 +53,7 @@ final class LogicalLineJoinerTests: XCTestCase {
   }
 
   /// Join as `copy(_:)` would on a 60-column terminal whose screen estimate
-  /// resolved to `W`.
+  /// resolved to `wrap`.
   private func join(_ rows: [String], screenWrapColumn: Int? = 58, firstRowWidth: Int? = nil)
     -> String
   {
@@ -67,7 +67,7 @@ final class LogicalLineJoinerTests: XCTestCase {
   func testWordWrappedCommandJoinsWithSpace() {
     let command =
       "git commit --no-verify -m 'refactor the wrapper' && git push origin HEAD --force-with-lease"
-    let rows = inkRows(command, width: W, firstIndent: "⏺ Bash(", indent: "      ")
+    let rows = inkRows(command, width: wrap, firstIndent: "⏺ Bash(", indent: "      ")
     XCTAssertGreaterThan(rows.count, 1, "fixture must wrap")
     XCTAssertEqual(join(rows), "⏺ Bash(" + command)
   }
@@ -78,7 +78,7 @@ final class LogicalLineJoinerTests: XCTestCase {
       "  npm run build -- --configuration production --output-dir",
       "  --no-cache dist",
     ]
-    XCTAssertEqual(rows[0].count, W)
+    XCTAssertEqual(rows[0].count, wrap)
     XCTAssertEqual(
       join(rows),
       "  npm run build -- --configuration production --output-dir --no-cache dist")
@@ -92,17 +92,17 @@ final class LogicalLineJoinerTests: XCTestCase {
     // split token, and no heuristic can tell those apart.
     let url = "https://example.com/" + String(repeating: "a", count: 60) + "/bbb.tar.gz"
     let command = "curl -fsSL \(url) -o out.tgz"
-    let rows = inkRows(command, width: W, firstIndent: "  ", indent: "  ")
+    let rows = inkRows(command, width: wrap, firstIndent: "  ", indent: "  ")
     XCTAssertEqual(rows.count, 3, "fixture must hard-split the URL once, then word-wrap")
-    XCTAssertEqual(rows[0].count, W)
-    XCTAssertLessThan(rows[1].count, W)
+    XCTAssertEqual(rows[0].count, wrap)
+    XCTAssertLessThan(rows[1].count, wrap)
     XCTAssertEqual(join(rows), "  " + command)
   }
 
   func testSoftWrappedRowAlreadyJoinedBySwiftTermIsLeftAlone() {
     // A row wider than the wrap column can only come from SwiftTerm joining
     // terminal-wrapped rows; it is never the head of an Ink wrap.
-    let long = String(repeating: "x", count: W + 10)
+    let long = String(repeating: "x", count: wrap + 10)
     XCTAssertEqual(join([long, "next"]), long + "\nnext")
   }
 
@@ -113,8 +113,8 @@ final class LogicalLineJoinerTests: XCTestCase {
       "Terminals draw text into a fixed grid of cells, so any line longer than the grid is wrapped."
     let p2 = "Some programs wrap the text themselves before it ever reaches the terminal."
     let rows =
-      inkRows(p1, width: W, firstIndent: "  ", indent: "  ") + [""]
-      + inkRows(p2, width: W, firstIndent: "  ", indent: "  ")
+      inkRows(p1, width: wrap, firstIndent: "  ", indent: "  ") + [""]
+      + inkRows(p2, width: wrap, firstIndent: "  ", indent: "  ")
     XCTAssertEqual(join(rows), "  " + p1 + "\n\n  " + p2)
   }
 
@@ -126,7 +126,7 @@ final class LogicalLineJoinerTests: XCTestCase {
   func testListItemsStaySeparateButWrappedItemJoins() {
     let item1 = "Read the buffer line by line and note which rows carry the wrapped flag"
     let rows =
-      inkRows(item1, width: W, firstIndent: "  - ", indent: "    ")
+      inkRows(item1, width: wrap, firstIndent: "  - ", indent: "    ")
       + ["  - Short second item", "  1. Numbered item", "  2. Another one", "  • Bulleted"]
     XCTAssertGreaterThan(rows.count, 5)
     XCTAssertEqual(
@@ -156,9 +156,9 @@ final class LogicalLineJoinerTests: XCTestCase {
 
   func testBoxDrawingRowsNeverJoin() {
     let rows = [
-      "╭" + String(repeating: "─", count: W - 2) + "╮",
+      "╭" + String(repeating: "─", count: wrap - 2) + "╮",
       "│ > some prompt text                                      │",
-      "╰" + String(repeating: "─", count: W - 2) + "╯",
+      "╰" + String(repeating: "─", count: wrap - 2) + "╯",
     ]
     XCTAssertEqual(join(rows), rows.joined(separator: "\n"))
   }
@@ -176,22 +176,22 @@ final class LogicalLineJoinerTests: XCTestCase {
     // estimate, but the selection's own full row does.
     let command =
       "git commit --no-verify -m 'refactor the wrapper' && git push origin HEAD --force-with-lease"
-    let rows = inkRows(command, width: W, firstIndent: "⏺ Bash(", indent: "      ")
+    let rows = inkRows(command, width: wrap, firstIndent: "⏺ Bash(", indent: "      ")
     XCTAssertEqual(join(rows, screenWrapColumn: nil), "⏺ Bash(" + command)
   }
 
   // MARK: - Review scenarios
 
   func testHardSplitInsideIndentedBlockUsesBlockTextWidth() {
-    // Ink splits a word when it exceeds the block's text width (W minus the
+    // Ink splits a word when it exceeds the block's text width (wrap minus the
     // continuation indent), not the full wrap column. A 55-char URL in a
     // "⏺ Bash(" block (51 columns of text) is split; the seam must close.
     let url = "https://x.io/" + String(repeating: "a", count: 42)
     XCTAssertEqual(url.count, 55)
     let head = "⏺ Bash(curl -fsSL "
-    let a = head + String(url.prefix(W - head.count))
-    let b = "      " + String(url.dropFirst(W - head.count)) + " -o out"
-    XCTAssertEqual(a.count, W)
+    let a = head + String(url.prefix(wrap - head.count))
+    let b = "      " + String(url.dropFirst(wrap - head.count)) + " -o out"
+    XCTAssertEqual(a.count, wrap)
     XCTAssertEqual(join([a, b]), head + url + " -o out")
   }
 
@@ -214,7 +214,7 @@ final class LogicalLineJoinerTests: XCTestCase {
   func testSelectionStartingMidRowUsesFullRowWidth() {
     let command =
       "git commit --no-verify -m 'refactor the wrapper' && git push origin HEAD --force-with-lease"
-    let rows = inkRows(command, width: W, firstIndent: "⏺ Bash(", indent: "      ")
+    let rows = inkRows(command, width: wrap, firstIndent: "⏺ Bash(", indent: "      ")
     // The drag began at the "g" of "git": SwiftTerm hands us only the tail
     // of the first row.
     var partial = rows
@@ -236,11 +236,11 @@ final class LogicalLineJoinerTests: XCTestCase {
 
   func testWrapColumnIgnoresInputBoxRowWithText() {
     let screen: [String?] = [
-      "  " + String(repeating: "t", count: W - 2),
+      "  " + String(repeating: "t", count: wrap - 2),
       "│ > Try \"fix the bug\"" + String(repeating: " ", count: 60 - 22) + "│",
       "╭" + String(repeating: "─", count: 58) + "╮",
     ]
-    XCTAssertEqual(LogicalLineJoiner.wrapColumn(forScreenRows: screen), W)
+    XCTAssertEqual(LogicalLineJoiner.wrapColumn(forScreenRows: screen), wrap)
   }
 
   // MARK: - Wrap column estimate
@@ -249,12 +249,12 @@ final class LogicalLineJoinerTests: XCTestCase {
     let border = String(repeating: "─", count: 60)
     let screen: [String?] = [
       "  Some short text",
-      "  " + String(repeating: "t", count: W - 2),
+      "  " + String(repeating: "t", count: wrap - 2),
       border,
       "> ",
       nil,
     ]
-    XCTAssertEqual(LogicalLineJoiner.wrapColumn(forScreenRows: screen), W)
+    XCTAssertEqual(LogicalLineJoiner.wrapColumn(forScreenRows: screen), wrap)
   }
 
   func testWrapColumnIsNilForEmptyScreen() {

--- a/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
+++ b/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
@@ -220,18 +220,68 @@ final class LogicalLineJoinerTests: XCTestCase {
     var partial = rows
     partial[0] = String(rows[0].dropFirst("⏺ Bash(".count))
     XCTAssertEqual(join(partial, firstRowWidth: rows[0].count), command)
-    // The screen-driven entry point recovers that width itself.
+    // The screen-driven entry point recovers that width itself, anchored on
+    // the row below matching the second selected line.
     let screen: [String?] = ["  header"] + rows.map { Optional($0) } + [nil]
     XCTAssertEqual(
       LogicalLineJoiner.join(partial.joined(separator: "\n"), columns: 60, screenRows: screen),
       command)
   }
 
-  func testFullRowWidthRequiresWordBoundary() {
-    let rows: [String?] = ["  foo ls -la", "  something else"]
-    XCTAssertEqual(LogicalLineJoiner.fullRowWidth(endingWith: "ls -la", in: rows), 12)
-    XCTAssertNil(LogicalLineJoiner.fullRowWidth(endingWith: "s -la", in: rows))
-    XCTAssertNil(LogicalLineJoiner.fullRowWidth(endingWith: "  foo ls -la", in: rows))
+  func testFullRowWidthRequiresWordBoundaryAndAnchor() {
+    let rows: [String?] = ["  foo ls -la", "  something else", "  ls -la", "  other"]
+    let next = "  something else"
+    XCTAssertEqual(
+      LogicalLineJoiner.fullRowWidth(endingWith: "ls -la", followedBy: next, in: rows), 12)
+    // Mid-word match is refused.
+    XCTAssertNil(LogicalLineJoiner.fullRowWidth(endingWith: "s -la", followedBy: next, in: rows))
+    // A line that already is the whole row needs no recovery.
+    XCTAssertNil(
+      LogicalLineJoiner.fullRowWidth(endingWith: "  foo ls -la", followedBy: next, in: rows))
+    // The row below must be the second selected line: the third row here also
+    // ends with the tail but is followed by "other", so it is not taken.
+    XCTAssertNil(
+      LogicalLineJoiner.fullRowWidth(endingWith: "ls -la", followedBy: "  nope", in: rows))
+  }
+
+  func testDecoyRowElsewhereOnScreenDoesNotInflateFirstLine() {
+    // The selection is two complete short lines. Another row on screen ends
+    // with the same word "done"; it must not lend its width to the first line.
+    let selection = "done\nNext independent line"
+    let screen: [String?] = [
+      "⏺ Bash(make && make test && echo done", "  ⎿  ok", "", "done", "Next independent line",
+    ]
+    XCTAssertEqual(
+      LogicalLineJoiner.join(selection, columns: 60, screenRows: screen), selection)
+  }
+
+  func testChromeRowInsideSelectionDoesNotHideHardSplit() {
+    // A drag across a turn boundary picks up the full-width rule row. It must
+    // not become the "widest row" and stop the URL seam from closing.
+    let url = "https://example.com/" + String(repeating: "a", count: 60) + "/bbb.tar.gz"
+    let command = "curl -fsSL \(url) -o out.tgz"
+    let rows =
+      inkRows(command, width: wrap, firstIndent: "  ", indent: "  ")
+      + [String(repeating: "─", count: 60)]
+    XCTAssertEqual(join(rows), "  " + command + "\n" + String(repeating: "─", count: 60))
+  }
+
+  func testMarkdownTableRowsStaySeparate() {
+    let rows = [
+      "  | id    | UUID   | Stable identifier for the session row |",
+      "  |-------|--------|---------------------------------------|",
+      "  | title | String | Display name shown in the sidebar lst |",
+    ]
+    XCTAssertEqual(join(rows), rows.joined(separator: "\n"))
+  }
+
+  func testDiffGutterRowsStaySeparate() {
+    let rows = [
+      "     12 +    let value = computeSomething(from: input, o)",
+      "     13 +    return value",
+      "     14      }",
+    ]
+    XCTAssertEqual(join(rows), rows.joined(separator: "\n"))
   }
 
   func testWrapColumnIgnoresInputBoxRowWithText() {

--- a/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
+++ b/Tests/DraftFrameTests/LogicalLineJoinerTests.swift
@@ -319,4 +319,19 @@ final class LogicalLineJoinerTests: XCTestCase {
     // symbols, are two columns to Ink's string-width as well.
     XCTAssertEqual(LogicalLineJoiner.displayWidth("🚀✅⚡🙂日"), 10)
   }
+
+  // MARK: - Gutter indent
+
+  func testStripCommonIndentRemovesGutterButKeepsRelativeIndent() {
+    let text = "  guard x else {\n      return\n  }\n\n  done"
+    XCTAssertEqual(
+      LogicalLineJoiner.stripCommonIndent(text), "guard x else {\n    return\n}\n\ndone")
+  }
+
+  func testStripCommonIndentLeavesColumnZeroTextAlone() {
+    let text = "⏺ Bash(ls)\n  ⎿  out"
+    XCTAssertEqual(LogicalLineJoiner.stripCommonIndent(text), text)
+    XCTAssertEqual(LogicalLineJoiner.stripCommonIndent("  single line"), "single line")
+    XCTAssertEqual(LogicalLineJoiner.stripCommonIndent(""), "")
+  }
 }


### PR DESCRIPTION
Closes #25

## Problem

Copying a wrapped command out of a Claude session and pasting it into a shell ran it as several broken commands, one per visual row.

The suspected cause in the ticket (SwiftTerm ignoring `isWrapped`) turned out not to be it: the existing `SoftWrapCopyTests` show SwiftTerm's copy path already joins terminal-soft-wrapped rows, and both Cmd+C and the context menu go through the same `_getSelectedLines`. The real cause is that Claude Code's Ink renderer wraps text itself at a content width short of the terminal edge and emits every visual row as a hard line, so `isWrapped` is never set and the terminal has nothing to join.

## Fix

`LogicalLineJoiner` replays Ink's `wrap-ansi` (`hard: true`) decision in reverse over the lines SwiftTerm produces. For adjacent rows `a` and `b`:

- **Hard split**: `a` is exactly as wide as the widest text row selected (Ink fills a row exactly when it splits a token) and the token straddling the seam is wider than the block's text width (wrap column minus continuation indent), the only case Ink splits inside a word. Joined with nothing, so URLs and paths reassemble intact.
- **Word wrap**: `a` plus a space plus `b`'s first word overflows the wrap column. Joined with a space.
- Everything else stays a hard newline: rows opening a list item, tool-call glyph, quote bar, table cell, diff line-number gutter or box frame; rows with shallower indent; blank rows.

The wrap column is the wider of the widest selected text row and the widest text row on screen (chrome rows edged with box-drawing are excluded from both), and must reach 60% of `term.cols` before any joining happens, so a few short lines never glue. When a drag starts mid-row, the first row's full width is recovered by matching the fragment against the on-screen row that is followed by the second selected line, so an unrelated row ending the same way is not taken.

After joining, the indent shared by every non-blank line (Claude Code's two-column gutter) is stripped, so a pasted paragraph starts at its first word while relative indentation inside a code block is preserved. This applies to single-line copies too.

`ClaudeTerminalView.copy(_:)` runs selections through the joiner; both Cmd+C and the context menu's Copy hit it. The heuristic is opt-in via `joinsWrappedRowsOnCopy`, which `SessionManager` enables for Claude Code sessions only. The Quick Terminal's zsh and Codex sessions keep SwiftTerm's plain copy: the terminal wraps there and SwiftTerm already handles it.

## Manual testing

`.claude/skills/copy-fixtures/SKILL.md` adds a `/copy-fixtures` command to run inside a Claude Code session in DraftFrame. It makes one harmless Bash `echo` call (so a `⏺ Bash(` header wraps) and then prints a verbatim block of fixtures, each with an `Expected:` line: wrapped header (including a mid-row drag start), prose paragraph, hard-split URL, lists, a Markdown table, a code block, wide glyphs, and a Quick Terminal control.

## Known limits

- Two independent lines that happen to satisfy the width test (a code line that nearly fills the width, followed by a line whose first token would not have fit) join with a space. This is the same ambiguity Ink creates; left as-is pending real-world signal.
- A row that is exactly full and ends in a long token, followed by a row starting with another long token, is byte-identical to a hard split and is joined with no separator.
- Once Claude Code exits and the pane is a bare zsh, the heuristic is still armed for that pane (the PTY process is the shell, so there is no exit signal for the agent itself).
- The blockquote copy buttons still join dequoted rows with newlines; wiring them to the joiner needs a different wrap column once the bar is stripped, so left for a follow-up.

## Tests

27 new tests in `LogicalLineJoinerTests`: wrapped `⏺ Bash(` commands, `--flag` and `>` continuation rows, hard-split URLs, paragraphs, lists, Markdown tables, Edit-tool diffs, indent decreases, chrome rows on screen and inside the selection, mid-row drag start with and without decoy rows, wide glyphs, gutter dedent. Full suite: 186 tests, 0 failures. `swift-format lint --strict` clean.