### PR TITLE
Show the repo name in the bottom right corner of each session card

### DIFF
--- a/Sources/DraftFrameKit/DFSessionBar.swift
+++ b/Sources/DraftFrameKit/DFSessionBar.swift
@@ -521,10 +521,26 @@ final class SessionCard: NSView {
       return label
     }()
 
+    // Repo the session lives in, bottom right. Branch names alone are
+    // ambiguous once several projects are open. Truncates from the head so
+    // the distinctive tail of a long name survives a narrow sidebar.
+    let repoLabel: NSTextField? = session.repoName.map { repoName in
+      let label = NSTextField(labelWithString: repoName)
+      label.font = Theme.mono(9)
+      label.textColor = Theme.text3
+      label.lineBreakMode = .byTruncatingHead
+      label.maximumNumberOfLines = 1
+      label.toolTip = session.repoRoot
+      label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+      label.translatesAutoresizingMaskIntoConstraints = false
+      return label
+    }
+
     for v in [avatar, nameLabel, dot, statusLabel, modelLabel, costLabel] as [NSView] {
       addSubview(v)
     }
     if let cl = contextLabel { addSubview(cl) }
+    if let rl = repoLabel { addSubview(rl) }
     if let badge = numberBadge { addSubview(badge) }
 
     // PR status pill (only if gh reports a PR for this worktree).
@@ -538,7 +554,14 @@ final class SessionCard: NSView {
       return label
     }
 
-    let cardHeight: CGFloat = contextLabel == nil ? 56 : 72
+    // The compact card grows to 64pt when a repo label is present: at 56pt
+    // the label would butt against the status/PR row.
+    let cardHeight: CGFloat
+    if contextLabel != nil {
+      cardHeight = 72
+    } else {
+      cardHeight = repoLabel == nil ? 56 : 64
+    }
 
     var constraints: [NSLayoutConstraint] = [
       heightAnchor.constraint(equalToConstant: cardHeight),
@@ -571,6 +594,23 @@ final class SessionCard: NSView {
         cl.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: 8),
         cl.topAnchor.constraint(equalTo: dot.bottomAnchor, constant: 5),
       ])
+    }
+    if let rl = repoLabel {
+      constraints.append(rl.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10))
+      if let cl = contextLabel {
+        // Share the bottom row with the context label; the repo label yields
+        // width first (low compression resistance) so the context figure
+        // never gets pushed around.
+        constraints.append(contentsOf: [
+          rl.centerYAnchor.constraint(equalTo: cl.centerYAnchor),
+          cl.trailingAnchor.constraint(lessThanOrEqualTo: rl.leadingAnchor, constant: -8),
+        ])
+      } else {
+        constraints.append(contentsOf: [
+          rl.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+          rl.leadingAnchor.constraint(greaterThanOrEqualTo: avatar.trailingAnchor, constant: 8),
+        ])
+      }
     }
     if let pill = prPill {
       constraints.append(contentsOf: [

--- a/Sources/DraftFrameKit/SessionManager.swift
+++ b/Sources/DraftFrameKit/SessionManager.swift
@@ -107,7 +107,9 @@ final class Session {
   /// `[1m]` variants). Resolved from Claude Code's startup banner via
   /// `PTYStreamAnalyzer.onContextWindowChange`.
   var maxContextTokens: Int
-  var worktreePath: String?
+  var worktreePath: String? {
+    didSet { if worktreePath != oldValue { cachedRepoRoot = nil } }
+  }
   var terminalView: ClaudeTerminalView?
 
   /// Label shown in the UI. When the session is on `main`/`master`, the bare
@@ -121,6 +123,36 @@ final class Session {
       return (projectRoot as NSString).lastPathComponent
     }
     return (path as NSString).lastPathComponent
+  }
+
+  /// Memoized `repoRoot`. `.some(nil)` records a lookup that found no repo so
+  /// the git spawn is not repeated every card rebuild; reset whenever
+  /// `worktreePath` changes.
+  private var cachedRepoRoot: String??
+
+  /// Root of the git repository that owns `worktreePath`, or nil when the
+  /// session has no worktree or the path is outside any repo. Managed
+  /// worktrees resolve by path alone; anything else asks git once and caches
+  /// the answer, so the once-a-second card refresh never spawns a process.
+  var repoRoot: String? {
+    if let cached = cachedRepoRoot { return cached }
+    let resolved: String? = {
+      guard let path = worktreePath else { return nil }
+      if let managed = WorktreeManager.managedRepoRoot(forWorktreePath: path) {
+        return managed
+      }
+      return WorktreeManager.repoRoot(at: path)
+    }()
+    cachedRepoRoot = .some(resolved)
+    return resolved
+  }
+
+  /// Folder name of `repoRoot` (e.g. `DraftFrame`), matching the project name
+  /// shown in the sidebar. Nil when there is no repo.
+  var repoName: String? {
+    guard let root = repoRoot else { return nil }
+    let name = (root as NSString).lastPathComponent
+    return name.isEmpty ? nil : name
   }
 
   /// Stable, unique-per-session seed for the generated avatar. Prefers the

--- a/Tests/DraftFrameTests/SessionRepoNameTests.swift
+++ b/Tests/DraftFrameTests/SessionRepoNameTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import DraftFrameKit
+
+/// `Session.repoName` feeds the repo label in the bottom right corner of each
+/// session card. Managed worktrees resolve by path; everything else asks git
+/// once and caches the answer.
+@MainActor
+final class SessionRepoNameTests: XCTestCase {
+
+  private var tempDir: URL!
+  private var repoDir: URL { tempDir.appendingPathComponent("MyRepo") }
+
+  override func setUpWithError() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("draftframe-reponame-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    git(["init", "-b", "main"], in: repoDir)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  private func git(_ args: [String], in dir: URL) {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    proc.arguments = ["-C", dir.path] + args
+    proc.standardOutput = FileHandle.nullDevice
+    proc.standardError = FileHandle.nullDevice
+    try? proc.run()
+    proc.waitUntilExit()
+  }
+
+  func testNoWorktreeHasNoRepoName() {
+    let session = Session(name: "scratch")
+    XCTAssertNil(session.repoRoot)
+    XCTAssertNil(session.repoName)
+  }
+
+  func testManagedWorktreeResolvesByPathWithoutGit() {
+    // The directory does not exist, so only the path-based resolution can
+    // produce an answer.
+    let session = Session(
+      name: "fix-login",
+      worktreePath: "/nonexistent/Projects/DraftFrame/.claude/worktrees/fix-login")
+    XCTAssertEqual(session.repoRoot, "/nonexistent/Projects/DraftFrame")
+    XCTAssertEqual(session.repoName, "DraftFrame")
+  }
+
+  func testPrimaryCheckoutResolvesThroughGit() {
+    let session = Session(name: "main", worktreePath: repoDir.path)
+    XCTAssertEqual(session.repoName, "MyRepo")
+    XCTAssertEqual(
+      URL(fileURLWithPath: session.repoRoot!).resolvingSymlinksInPath().path,
+      repoDir.resolvingSymlinksInPath().path)
+  }
+
+  func testSubdirectoryOfRepoResolvesToRepoName() throws {
+    let sub = repoDir.appendingPathComponent("Sources/Deep")
+    try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+    let session = Session(name: "feature", worktreePath: sub.path)
+    XCTAssertEqual(session.repoName, "MyRepo")
+  }
+
+  func testPathOutsideAnyRepoHasNoRepoName() throws {
+    let plain = tempDir.appendingPathComponent("plain")
+    try FileManager.default.createDirectory(at: plain, withIntermediateDirectories: true)
+    // Guard against a git repo enclosing the temp directory on the test host.
+    let session = Session(name: "plain", worktreePath: plain.path)
+    if WorktreeManager.repoRoot(at: tempDir.path) == nil {
+      XCTAssertNil(session.repoName)
+    }
+  }
+
+  func testChangingWorktreePathInvalidatesCache() {
+    let session = Session(
+      name: "a", worktreePath: "/x/Alpha/.claude/worktrees/a")
+    XCTAssertEqual(session.repoName, "Alpha")
+    session.worktreePath = "/x/Beta/.claude/worktrees/a"
+    XCTAssertEqual(session.repoName, "Beta")
+    session.worktreePath = nil
+    XCTAssertNil(session.repoName)
+  }
+
+  func testDisplayNameSubstitutionUnchanged() {
+    let session = Session(
+      name: "main", worktreePath: "/x/Alpha/.claude/worktrees/main")
+    XCTAssertEqual(session.displayName, "Alpha")
+    let branch = Session(
+      name: "fix-login", worktreePath: "/x/Alpha/.claude/worktrees/fix-login")
+    XCTAssertEqual(branch.displayName, "fix-login")
+  }
+}


### PR DESCRIPTION
Closes #32

## Summary

- Add `Session.repoRoot` / `Session.repoName`, resolved from `worktreePath`: managed worktrees resolve by path with no process spawn, anything else asks `git rev-parse --show-toplevel` once (with `WorktreeManager.gitEnvironment()`) and caches the answer per session. Setting `worktreePath` resets the cache so worktree renames stay correct. `displayName` keeps its `main`/`master` substitution.
- Add a `repoLabel` to `SessionCard` pinned to the bottom right in the `Theme.mono(9)` / `Theme.text3` style. It truncates from the head, has low horizontal compression resistance, and its tooltip is the full repo root path. Sessions with no worktree or outside any git repo show nothing.
- The compact card grows from 56pt to 64pt when a repo label is present; at 56pt the label butted against the status/PR row. On the 72pt card the repo label shares the bottom row with the context label, aligned on the context label's centre, and the context label is constrained to stay clear of it.
- New `SessionRepoNameTests` cover no worktree, managed worktree, primary checkout, subdirectory, non-repo path, cache invalidation on path change, and the unchanged `displayName` behaviour.

## Decision

On `main` sessions the repo name appears both in the name row and in the corner. The corner label is kept in that case so every card in a list has the same height.

## Verification

- `swift test`: 166 tests, 0 failures.
- QA run with two scratch repos both on a `fix-login` branch: each card shows its own repo name, a long name truncates from the head, a session in `/tmp` has an empty corner with no logged errors, and a session with a live context label renders the 72pt card with the context figure and repo name side by side without overlapping the cost label.
- Not exercised in the app: a card with a PR pill (no scratch repo had a PR).